### PR TITLE
Delete visually selected path when clicking the delete path button.

### DIFF
--- a/src/data/Image.vala
+++ b/src/data/Image.vala
@@ -353,10 +353,20 @@ public class Image : Gtk.TreeStore {
 }*/
     }
 
-    public void delete_path () {
-        remove (ref selected_path);
-        selected_path = null;
-        path_selected (null);
+    public void delete_path (Gtk.TreeIter? iter=null) {
+        if (iter == null) {
+            iter = last_selected_path;
+        }
+ 
+        if (iter != null) {
+            if (iter == last_selected_path) {
+                last_selected_path = null;
+                selected_path = null;
+                path_selected (null);
+            }
+            remove (ref iter);
+            update ();
+       }
     }
 
     private void save_xml () {

--- a/src/widgets/EditorView.vala
+++ b/src/widgets/EditorView.vala
@@ -2,6 +2,7 @@ public class EditorView : Gtk.Box {
     public Image image { get; private set; }
 
     private Gtk.TreeView paths_list;
+    private Gtk.TreeSelection selection;
     private Viewport viewport;
 
     public EditorView (Image image) {
@@ -71,6 +72,7 @@ public class EditorView : Gtk.Box {
             var element = image.get_element (iter);
             element.select (true);
         });
+        selection = paths_list.get_selection ();
 
         var list_box_scroll = new Gtk.ScrolledWindow (null, null);
         list_box_scroll.propagate_natural_width = true;
@@ -122,7 +124,10 @@ public class EditorView : Gtk.Box {
         delete_path.tooltip_text = _("Delete path");
         delete_path.relief = NONE;
         delete_path.clicked.connect (() => {
-            image.delete_path ();
+            Gtk.TreeIter iter;
+            if (selection.get_selected (null, out iter)) {
+                image.delete_path (iter);
+            }
         });
 
         var task_bar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);


### PR DESCRIPTION
Previously, pressing the delete button would delete the selected path, printing an error if no path had been selected or the selected path had already been deleted. This fix gets the path to delete from the path list's selection object, then only deletes a path if a path is selected in the viewer. 