### PR TITLE
Bugfix: deselect deleted path

### DIFF
--- a/src/data/Image.vala
+++ b/src/data/Image.vala
@@ -438,12 +438,15 @@ public class Image : Gtk.TreeStore {
         }
  
         if (iter != null) {
+            if (iter == selected_path) {
+                path_selected (null, null);
+                selected_path = null;
+            }
+
             remove (ref iter);
 
             if (iter == last_selected_path) {
                 last_selected_path = null;
-                selected_path = null;
-                path_selected (null, null);
             }
 
             update ();


### PR DESCRIPTION
For some reason, some paths weren't being deselected after deleting, which resulted in crashing when clicking later. This now checks before removing the path if the path is selected and deselects it.