### PR TITLE
Bugfix: Null checks

### DIFF
--- a/src/data/Element.vala
+++ b/src/data/Element.vala
@@ -1,7 +1,27 @@
 public abstract class Element : Object, Undoable {
-    public virtual Pattern? stroke { get; set; }
+    private Pattern _fill;
+    public Pattern fill {
+        get {
+            return _fill;
+        }
+        set {
+            _fill = value;
+            fill.update.connect (() => { update (); });
+            fill.add_command.connect ((c) => { add_command(c); });
+        }
+    }
 
-    public virtual Pattern? fill { get; set; }
+    private Pattern _stroke;
+    public Pattern stroke {
+        get {
+            return _stroke;
+        }
+        set {
+            _stroke = value;
+            stroke.update.connect (() => { update (); });
+            stroke.add_command.connect ((c) => { add_command(c); });
+        }
+    }
 
     private Transform _transform;
     public Transform transform {

--- a/src/data/Group.vala
+++ b/src/data/Group.vala
@@ -2,8 +2,8 @@ public class Group : Element {
     public Group () {
         title = "Group";
         visible = true;
-        fill = null;
-        stroke = null;
+        fill = new Pattern.none ();
+        stroke = new Pattern.none ();
         transform = new Transform.identity ();
    
         setup_signals ();

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -8,7 +8,7 @@ public class Line : Element {
     public Line (double x1, double y1, double x2, double y2, Pattern stroke, string? title = null) {
         this.start = { x1, y1 };
         this.end = { x2, y2 };
-        this.fill = null;
+        this.fill = new Pattern.none ();
         this.stroke = stroke;
         visible = true;
         if (title == null) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -1,30 +1,6 @@
 public class Path : Element {
     public PathSegment root_segment;
 
-    private Pattern _fill;
-    public override Pattern? fill {
-        get {
-            return _fill;
-        }
-        set {
-            _fill = value;
-            fill.update.connect (() => { update (); });
-            fill.add_command.connect ((c) => { add_command(c); });
-        }
-    }
-
-    private Pattern _stroke;
-    public override Pattern? stroke {
-        get {
-            return _stroke;
-        }
-        set {
-            _stroke = value;
-            stroke.update.connect (() => { update (); });
-            stroke.add_command.connect ((c) => { add_command(c); });
-        }
-    }
-
     private Point last_reference;
 
     // I'll probably remove this entirely later.

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -241,7 +241,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             var y = scale_y (event.y);
             control_point = {x, y};
             // Check for right-clicking on a segment
-            if (event.button == 3) {
+            if (path != null && event.button == 3) {
                 if (clicked) {
                     path.select (true);
                 }


### PR DESCRIPTION
This fixes runtime warnings for right clicking in a space without an element and having null patterns (which are no longer allowed anywhere).