### PR TITLE
Various selection fixes

### DIFF
--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -493,12 +493,14 @@ public interface Container : Undoable, Updatable, Transformed {
         var index = 0;
         var elem = model.get_item (index) as Element;
         while (elem != null) {
-            var new_x = x, new_y = y;
-            var new_tolerance = tolerance;
-            elem.transform.update_point (x, y, out new_x, out new_y);
-            elem.transform.update_distance (tolerance, out new_tolerance);
-            if (elem.clicked (new_x, new_y, new_tolerance, out element, out segment)) {
-                return true;
+            if (elem.visible) {
+                var new_x = x, new_y = y;
+                var new_tolerance = tolerance;
+                elem.transform.update_point (x, y, out new_x, out new_y);
+                elem.transform.update_distance (tolerance, out new_tolerance);
+                if (elem.clicked (new_x, new_y, new_tolerance, out element, out segment)) {
+                    return true;
+                }
             }
 
             index += 1;

--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -57,6 +57,7 @@ public interface Container : Undoable, Updatable, Transformed {
         if (value.selection != null && value.selection != selected_child) {
             value.selection.select (true);
         }
+
         update ();
     }
 
@@ -329,7 +330,12 @@ public interface Container : Undoable, Updatable, Transformed {
         var cont = element as Container;
         if (cont != null) {
             signal_manager.path_selected = cont.path_selected.connect ((elem) => {
-                selected_child = element;
+                if (elem == null) {
+                    selected_child = null;
+                } else {
+                    selected_child = element;
+                }
+
                 path_selected (elem);
             });
 

--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -32,7 +32,7 @@ public interface Container : Undoable, Updatable, Transformed {
         }
     }
 
-    protected abstract Element? selected_child { get; set; }
+    public abstract Element? selected_child { get; protected set; }
     protected abstract Gee.Map<Element, ElementSignalManager> signal_managers { get; set; }
 
     // This has to be abstract so it exists in the child classes

--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -483,7 +483,10 @@ public interface Container : Undoable, Updatable, Transformed {
             selected_child.check_controls (new_x, new_y, new_tolerance, out inner_handle);
             if (inner_handle != null) {
                 selected_child.clicked (new_x, new_y, new_tolerance, out element, out segment); // Just for if a segment was also clicked
-                element = selected_child;
+                if (element == null) {
+                    element = selected_child;
+                }
+
                 handle = new TransformedHandle (inner_handle, element.transform);
                 return true;
             }

--- a/src/data/Image.vala
+++ b/src/data/Image.vala
@@ -222,6 +222,7 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
                              {0.33f, 0.33f, 0.33f, 1f},
                              "New Path");
         add_element (path);
+        path.select (true);
     }
 
     public void new_circle () {
@@ -229,21 +230,25 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
                                  new Pattern.color ({0.66f, 0.66f, 0.66f, 1}),
                                  new Pattern.color ({0.33f, 0.33f, 0.33f, 1}));
         add_element (circle);
+        circle.select (true);
     }
 
     public void new_rectangle () {
         var rectangle = new Rectangle (2.5, 2.5, width - 5, height - 5, new Pattern.color ({0.66f, 0.66f, 0.66f, 1}), new Pattern.color ({0.33f, 0.33f, 0.33f, 1}));
         add_element (rectangle);
+        rectangle.select (true);
     }
 
     public void new_ellipse () {
         var ellipse = new Ellipse (width / 2, height / 2, width / 2 - 5, height / 2 - 5, new Pattern.color ({0.66f, 0.66f, 0.66f, 1}), new Pattern.color ({0.33f, 0.33f, 0.33f, 1}));
         add_element (ellipse);
+        ellipse.select (true);
     }
 
     public void new_line () {
         var line = new Line (1.5, 1.5, width - 1.5, height - 1.5, new Pattern.color ({0.33f, 0.33f, 0.33f, 1}));
         add_element (line);
+        line.select (true);
     }
 
     public void new_polyline () {
@@ -255,6 +260,7 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
                                  new Pattern.color ({0.33f, 0.33f, 0.33f, 1}),
                                  "New Polyline");
         add_element (line);
+        line.select (true);
     }
 
     public void new_polygon () {
@@ -266,11 +272,13 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
                                  new Pattern.color ({0.33f, 0.33f, 0.33f, 1}),
                                  "New Polygon");
         add_element (shape);
+        shape.select (true);
     }
 
     public void new_group () {
         var group = new Group ();
         add_element (group);
+        group.select (true);
     }
 
     private void save_xml () {

--- a/src/widgets/EditorView.vala
+++ b/src/widgets/EditorView.vala
@@ -18,6 +18,9 @@ public class EditorView : Gtk.Box {
                     var elem = (Element) image.tree.get_row (position).item;
                     if (elem == e) {
                         selection.selected = position;
+                        var adj = paths_list.vadjustment;
+                        adj.value = position * (adj.upper - adj.lower) / image.tree.get_n_items () + adj.lower;
+                        paths_list.vadjustment = adj;
                     }
                 }
             }

--- a/src/widgets/EditorView.vala
+++ b/src/widgets/EditorView.vala
@@ -14,13 +14,23 @@ public class EditorView : Gtk.Box {
         viewport.image = image;
         image.path_selected.connect ((e) => {
             if (e != null) {
-                for (var position = 0; position < image.tree.get_n_items (); position++) {
+                Container current_parent = image.selected_child as Container;
+                var num_rows = image.tree.n_items;
+                var start_rows = num_rows;
+                for (var position = 0; position < num_rows; position++) {
                     var elem = (Element) image.tree.get_row (position).item;
                     if (elem == e) {
                         selection.selected = position;
+                        // Once elementary updates to Gtk 4.12, this can be replaced with scroll_to
                         var adj = paths_list.vadjustment;
-                        adj.value = position * (adj.upper - adj.lower) / image.tree.get_n_items () + adj.lower;
+                        adj.upper = (adj.upper - adj.lower) * num_rows / start_rows + adj.lower;
+                        adj.value = (position - num_rows + start_rows) * (adj.upper - adj.lower) / num_rows + adj.lower;
                         paths_list.vadjustment = adj;
+                        return;
+                    } else if (elem as Container == current_parent && current_parent != null) {
+                        image.tree.get_row (position).expanded = true;
+                        num_rows = image.tree.get_n_items ();
+                        current_parent = current_parent.selected_child as Container;
                     }
                 }
             }
@@ -29,6 +39,15 @@ public class EditorView : Gtk.Box {
             var row = (Gtk.TreeListRow) selection.selected_item;
             var e = (Element) row.item;
             if (e != null) {
+                var parent = (Container) image;
+                while (parent != null) {
+                    if (parent.selected_child == e) {
+                        return;
+                    }
+
+                    parent = parent.selected_child as Container;
+                }
+
                 if (image.has_selected ()) {
                     image.deselect ();
                 }

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -36,7 +36,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             _image.update.connect (() => {
                 queue_draw ();
             });
-            image.notify["selected_child"].connect (() => {
+            image.path_selected.connect (() => {
                 current_handle = null;
             });
             scroll_x = -_image.width / 2;

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -36,6 +36,9 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             _image.update.connect (() => {
                 queue_draw ();
             });
+            image.notify["selected_child"].connect (() => {
+                current_handle = null;
+            });
             scroll_x = -_image.width / 2;
             scroll_y = -_image.height / 2;
         }

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -221,12 +221,12 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
                 Segment segment;
                 Handle handle;
                 if (image.clicked_child (scale_x (x), scale_y (y), 6 / zoom, out path, out segment, out handle)) {
-                    current_handle = handle;
                     if (tutorial != null && tutorial.step == CLICK) {
                         tutorial.next_step ();
                     }
 
                     path.select (true);
+                    current_handle = handle;
                 } else {
                     image.deselect ();
                     current_handle = null;
@@ -242,8 +242,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             Segment segment;
             Handle handle;
             if (image.clicked_child (scale_x (x), scale_y (y), 6 / zoom, out path, out segment, out handle)) {
-                current_handle = handle;
                 path.select (true);
+                current_handle = handle;
                 show_context_menu (path, segment, handle, x, y);
             }
         });


### PR DESCRIPTION
There were several inconsistencies and illogical behaviors in how selections worked. This cleans them up.

Updates include:
* Selecting new elements by default
* Deselecting handles when the containing element is deselected or deleted
* Not selecting invisible elements
* Keeping the same element selected when reordering them in the side bar