### PR TITLE
Clean up Patterns

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ executable(
     'src/data/Handle.vala',
     'src/data/BaseHandle.vala',
     'src/data/TransformedHandle.vala',
+    'src/data/PatternSegment.vala',
     gresource_froggum,
     dependencies: [
         dependency('gtk4'),

--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -164,6 +164,10 @@ public class Circle : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         segment = null;
         if ((Math.sqrt ((x - this.x) * (x - this.x) + (y - this.y) * (y - this.y)) - r).abs () <= tolerance) {
             element = this;

--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -121,7 +121,7 @@ public class Circle : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Circle"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Circle"), () => { request_delete(); }),
             new ContextOption.action (_("Convert to Ellipse"), () => { replace (new Ellipse (x, y, r, r, fill, stroke, title, transform)); }),
             new ContextOption.toggle (_("Show Transformation"), this, "transform_enabled")
         });

--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -141,7 +141,7 @@ public class Circle : Element {
     }
 
     public override Element copy () {
-        return new Circle (x, y, r, fill, stroke);
+        return new Circle (x, y, r, fill.copy (), stroke.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/ContextOption.vala
+++ b/src/data/ContextOption.vala
@@ -3,6 +3,7 @@ public enum ContextOptionType {
     ACTION,
     TOGGLE,
     OPTIONS,
+    COLOR,
 }
 
 public class ContextOption : Object {
@@ -27,6 +28,13 @@ public class ContextOption : Object {
 
     public ContextOption.toggle (string label, Undoable obj, string prop) {
         option_type = TOGGLE;
+        this.label = label;
+        this.target = obj;
+        this.prop = prop;
+    }
+
+    public ContextOption.color (string label, Undoable obj, string prop) {
+        option_type = COLOR;
         this.label = label;
         this.target = obj;
         this.prop = prop;

--- a/src/data/ContextOption.vala
+++ b/src/data/ContextOption.vala
@@ -4,6 +4,7 @@ public enum ContextOptionType {
     TOGGLE,
     OPTIONS,
     COLOR,
+    DELETER,
 }
 
 public class ContextOption : Object {
@@ -22,6 +23,12 @@ public class ContextOption : Object {
 
     public ContextOption.action (string label, owned ActionCallback callback) {
         option_type = ACTION;
+        this.label = label;
+        this.callback = (owned) callback;
+    }
+
+    public ContextOption.deleter (string label, owned ActionCallback callback) {
+        option_type = DELETER;
         this.label = label;
         this.callback = (owned) callback;
     }

--- a/src/data/Element.vala
+++ b/src/data/Element.vala
@@ -124,4 +124,20 @@ public abstract class Element : Object, Undoable, Updatable, Transformed {
     }
 
     public abstract bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment);
+
+    public bool check_standard_clicks (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (fill.clicked (x, y, tolerance, out segment)) {
+            element = this;
+            return true;
+        }
+
+        if (stroke.clicked(x, y, tolerance, out segment)) {
+            element = this;
+            return true;
+        }
+
+        element = null;
+        segment = null;
+        return false;
+    }
 }

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -234,7 +234,7 @@ public class Ellipse : Element {
     }
 
     public override Element copy () {
-        return new Ellipse (cx, cy, rx, ry, fill, stroke);
+        return new Ellipse (cx, cy, rx, ry, fill.copy (), stroke.copy ());
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -205,7 +205,7 @@ public class Ellipse : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Ellipse"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Ellipse"), () => { request_delete(); }),
             new ContextOption.action (_("Convert to Path"), () => { 
                 replace (new Path.with_pattern ({
                     new PathSegment.line (cx - rx, cy),

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -238,6 +238,10 @@ public class Ellipse : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         segment = null;
         var surf = new Cairo.ImageSurface (Cairo.Format.ARGB32, 1, 1);
         var cr = new Cairo.Context (surf);

--- a/src/data/Image.vala
+++ b/src/data/Image.vala
@@ -91,68 +91,9 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
             for (Xml.Node* iter = root->children; iter != null; iter = iter->next) {
                 if (iter->name == "defs") {
                     for (Xml.Node* def = iter->children; def != null; def = def->next) {
-                        if (def->name == "linearGradient") {
+                        var pattern = Pattern.load_xml (def);
+                        if (pattern != null) {
                             var name = def->get_prop ("id");
-                            var x1 = double.parse (def->get_prop ("x1"));
-                            var y1 = double.parse (def->get_prop ("y1"));
-                            var x2 = double.parse (def->get_prop ("x2"));
-                            var y2 = double.parse (def->get_prop ("y2"));
-                            var pattern = new Pattern.linear ({x1, y1}, {x2, y2});
-                            
-                            for (Xml.Node* stop = def->children; stop != null; stop = stop->next) {
-                                var offset_data = stop->get_prop ("offset");
-                                double offset;
-                                if (offset_data == null) {
-                                    offset = 0;
-                                } else if (offset_data.has_suffix ("%")) {
-                                    offset = double.parse (offset_data.substring (0, offset_data.length - 1)) / 100;
-                                } else {
-                                    offset = double.parse (offset_data);
-                                }
-                                var color = process_color (stop->get_prop ("stop-color") ?? "#000");
-                                var opacity = stop->get_prop ("stop-opacity");
-                                if (opacity != null) {
-                                    if (opacity.has_suffix ("%")) {
-                                        color.alpha = float.parse (opacity.substring (0, opacity.length - 1)) / 100;
-                                    } else {
-                                        color.alpha = float.parse (opacity);
-                                    }
-                                }
-                                pattern.add_stop (new Stop (offset, color));
-                            }
-                            
-                            patterns.@set (name, pattern);
-                        } else if (def->name == "radialGradient") {
-                            var name = def->get_prop ("id");
-                            var cx = double.parse (def->get_prop ("cx"));
-                            var cy = double.parse (def->get_prop ("cy"));
-                            var r = double.parse (def->get_prop ("r"));
-                            var pattern = new Pattern.radial ({cx, cy}, {cx + r, cy});
-                            
-                            for (Xml.Node* stop = def->children; stop != null; stop = stop->next) {
-                                if (stop->name == "stop") {
-                                    var offset_data = stop->get_prop ("offset");
-                                    double offset;
-                                    if (offset_data == null) {
-                                        offset = 0;
-                                    } else if (offset_data.has_suffix ("%")) {
-                                        offset = float.parse (offset_data.substring (0, offset_data.length - 1)) / 100;
-                                    } else {
-                                        offset = float.parse (offset_data);
-                                    }
-                                    var color = process_color (stop->get_prop ("stop-color") ?? "#000");
-                                    var opacity = stop->get_prop ("stop-opacity");
-                                    if (opacity != null) {
-                                        if (opacity.has_suffix ("%")) {
-                                            color.alpha = float.parse (opacity.substring (0, opacity.length - 1)) / 100;
-                                        } else {
-                                            color.alpha = float.parse (opacity);
-                                        }
-                                    }
-                                    pattern.add_stop (new Stop (offset, color));
-                                }
-                            }
-                            
                             patterns.@set (name, pattern);
                         }
                     }

--- a/src/data/Image.vala
+++ b/src/data/Image.vala
@@ -105,28 +105,6 @@ public class Image : Object, Undoable, Updatable, Transformed, Container {
         already_loaded = true;
     }
 
-    private Gdk.RGBA process_color (string color) {
-        var rgba = Gdk.RGBA ();
-        if (color.has_prefix ("rgb(")) {
-            var channels = color.substring (4, color.length - 5).split (",");
-            rgba.red = int.parse (channels[0]) / 255.0f;
-            rgba.green = int.parse (channels[1]) / 255.0f;
-            rgba.blue = int.parse (channels[2]) / 255.0f;
-        } else if (color.has_prefix ("rgba(")) {
-            var channels = color.substring (5, color.length - 6).split (",");
-            rgba.red = int.parse (channels[0]) / 255.0f;
-            rgba.green = int.parse (channels[1]) / 255.0f;
-            rgba.blue = int.parse (channels[2]) / 255.0f;
-            rgba.alpha = float.parse (channels[3]);
-        } else if (color.has_prefix ("#")) {
-            var color_length = (color.length - 1) / 3;
-            color.substring (1, color_length).scanf ("%x", &rgba.red);
-            color.substring (1 + color_length, color_length).scanf ("%x", &rgba.green);
-            color.substring (1 + 2 * color_length, color_length).scanf ("%x", &rgba.blue);
-        }
-        return rgba;
-    }
-
     public File file {
         get {
             return _file;

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -106,7 +106,7 @@ public class Line : Element {
     }
 
     public override Element copy () {
-        return new Line (start.x, start.y, end.x, end.y, stroke);
+        return new Line (start.x, start.y, end.x, end.y, stroke.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -129,6 +129,10 @@ public class Line : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         var dot = (x - start.x) * (end.x - start.x) + (y - start.y) * (end.y - start.y);
         var len_squared = (end.x - start.x) * (end.x - start.x) + (end.y - start.y) * (end.y - start.y);
         var scale = dot / len_squared;

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -83,7 +83,7 @@ public class Line : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Line"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Line"), () => { request_delete(); }),
             new ContextOption.action (_("Convert to Polyline"), () => {
                 replace (new Polyline ({start, end}, fill, stroke, title, transform));
             }),

--- a/src/data/Parser.vala
+++ b/src/data/Parser.vala
@@ -175,6 +175,18 @@ public class Parser : Object {
         }
     }
 
+    public Gdk.RGBA? get_color () {
+        var rgba = Gdk.RGBA ();
+        if (rgba.parse (data)) {
+            // Assume the color was the entire data
+            data = "";
+            return rgba;
+        } else {
+            return null;
+        }
+    }
+
+
     public bool empty () {
         return data.length == 0;
     }

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -146,7 +146,8 @@ public class Path : Element {
             new_segments += current_segment.copy ();
             current_segment = current_segment.next;
         }
-        return new Path.with_pattern (new_segments, fill, stroke, title);
+
+        return new Path.with_pattern (new_segments, fill.copy (), stroke.copy (), title);
     }
 
     public void split_segment (PathSegment segment) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -295,6 +295,10 @@ public class Path : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         var current_segment = root_segment;
         var first = true;
         while (first || current_segment != root_segment) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -221,7 +221,7 @@ public class Path : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Path"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Path"), () => { request_delete(); }),
             new ContextOption.toggle (_("Show Transformation"), this, "transform_enabled")
         });
     }

--- a/src/data/Pattern.vala
+++ b/src/data/Pattern.vala
@@ -165,6 +165,11 @@ public class Pattern : Object, ListModel, Undoable {
                 pattern = new Cairo.Pattern.rgba (rgba.red, rgba.green, rgba.blue, rgba.alpha);
                 break;
             case LINEAR:
+                if (stops.size == 0) {
+                    add_stop (new Stop (0.0, rgba));
+                    add_stop (new Stop (1.0, rgba));
+                }
+
                 pattern = new Cairo.Pattern.linear (start.x, start.y, end.x, end.y);
                 for (int i = 0; i < stops.size; i++) {
                     var s = stops.@get (i);
@@ -172,6 +177,11 @@ public class Pattern : Object, ListModel, Undoable {
                 }
                 break;
             case RADIAL:
+                if (stops.size == 0) {
+                    add_stop (new Stop (0.0, rgba));
+                    add_stop (new Stop (1.0, rgba));
+                }
+
                 pattern = new Cairo.Pattern.radial (start.x, start.y, 0, start.x, start.y, Math.hypot (start.x - end.x, start.y - end.y));
                 for (int i = 0; i < stops.size; i++) {
                     var s = stops.@get (i);

--- a/src/data/Pattern.vala
+++ b/src/data/Pattern.vala
@@ -470,7 +470,7 @@ public class Pattern : Object, ListModel, Undoable {
                 if ((x - stop.display.x).abs () <= tolerance &&
                     (y - stop.display.y).abs () <= tolerance) {
                     var opts = new Gee.ArrayList<ContextOption> ();
-                    opts.add (new ContextOption.action (_("Delete Stop"), () => { delete_stop (stop); }));
+                    opts.add (new ContextOption.deleter (_("Delete Stop"), () => { delete_stop (stop); }));
                     opts.add (new ContextOption.color (_("Change Color"), stop, "rgba"));
                     handle = new BaseHandle(stop, "display", opts);
                     return true;

--- a/src/data/Pattern.vala
+++ b/src/data/Pattern.vala
@@ -471,6 +471,7 @@ public class Pattern : Object, ListModel, Undoable {
                     (y - stop.display.y).abs () <= tolerance) {
                     var opts = new Gee.ArrayList<ContextOption> ();
                     opts.add (new ContextOption.action (_("Delete Stop"), () => { delete_stop (stop); }));
+                    opts.add (new ContextOption.color (_("Change Color"), stop, "rgba"));
                     handle = new BaseHandle(stop, "display", opts);
                     return true;
                 }

--- a/src/data/Pattern.vala
+++ b/src/data/Pattern.vala
@@ -494,6 +494,35 @@ public class Pattern : Object, ListModel, Undoable {
         return false;
     }
 
+    public bool clicked (double x, double y, double tolerance, out Segment? segment) {
+        if (pattern_type == LINEAR || pattern_type == RADIAL) {
+            if ((x - start.x).abs () <= tolerance &&
+                (y - start.y).abs () <= tolerance) {
+                segment = new PatternSegment (this, 0.0);
+                return true;
+            }
+
+            if ((x - end.x).abs () <= tolerance &&
+                (y - end.y).abs () <= tolerance) {
+                segment = new PatternSegment(this, 1.0);
+                return true;
+            }
+
+            var ds = (x - start.x) * (end.x - start.x) + (y - start.y) * (end.y - start.y);
+            var aligned_offset = ds / ((end.x - start.x) * (end.x - start.x) + (end.y - start.y) * (end.y - start.y));
+            if (0 < aligned_offset && aligned_offset < 1) {
+                Point inner_point = { start.x + aligned_offset * (end.x - start.x), start.y + aligned_offset * (end.y - start.y) };
+                if (inner_point.dist ({x, y}) <= tolerance) {
+                    segment = new PatternSegment (this, aligned_offset);
+                    return true;
+                }
+            }
+        }
+
+        segment = null;
+        return false;
+    }
+
     private void delete_stop (Stop stop) {
         var index = stops.index_of (stop);
         if (index < 0) {

--- a/src/data/PatternSegment.vala
+++ b/src/data/PatternSegment.vala
@@ -1,0 +1,23 @@
+public class PatternSegment : Segment {
+    private Pattern parent;
+    private double offset;
+
+    public PatternSegment (Pattern parent, double offset) {
+        this.parent = parent;
+        this.offset = offset;
+    }
+
+    public override Gee.List<ContextOption> options () {
+        return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
+            new ContextOption.action (_("Add Stop"), () => {
+                var stop = new Stop (offset, parent.rgba);
+                parent.add_stop (stop);
+            })
+        });
+    }
+
+
+    // This has no properties to save right now
+    public override void begin (string prop) {}
+    public override void finish (string prop) {}
+}

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -150,7 +150,7 @@ public class Polygon : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Polygon"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Polygon"), () => { request_delete(); }),
             new ContextOption.action (_("Convert to Path"), () => {
                 var segments = new PathSegment[] {};
                 var seg = root_segment;

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -191,7 +191,7 @@ public class Polygon : Element {
             first = false;
         }
 
-        return new Polygon (points, fill, stroke, "Copy of " + title, transform);
+        return new Polygon (points, fill.copy (), stroke.copy (), "Copy of " + title, transform);
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -230,6 +230,10 @@ public class Polygon : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         segment = null;
 
         var first = true;

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -188,7 +188,7 @@ public class Polyline : Element {
             points += segment.end;
         }
 
-        return new Polyline (points, fill, stroke, "Copy of " + title, transform);
+        return new Polyline (points, fill.copy (), stroke.copy (), "Copy of " + title, transform);
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -207,6 +207,10 @@ public class Polyline : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         for (var lsegment = root_segment; lsegment != null; lsegment = lsegment.next) {
             if (lsegment.clicked (x, y, tolerance)) {
                 element = this;

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -153,7 +153,7 @@ public class Polyline : Element {
 
     public override Gee.List<ContextOption> options () {
         return new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Polyline"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Polyline"), () => { request_delete(); }),
             new ContextOption.action (_("Close Loop"), () => {
                 var points = new Point[] {root_segment.start};
                 for (var segment = root_segment; segment != null; segment = segment.next) {

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -458,7 +458,7 @@ public class Rectangle : Element {
 
     public override Gee.List<ContextOption> options () {
         var options = new Gee.ArrayList<ContextOption>.wrap (new ContextOption[]{
-            new ContextOption.action (_("Delete Rectangle"), () => { request_delete(); }),
+            new ContextOption.deleter (_("Delete Rectangle"), () => { request_delete(); }),
             new ContextOption.toggle (_("Round Corners"), this, "rounded"),
             new ContextOption.toggle (_("Show Transformation"), this, "transform_enabled")
         });

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -506,7 +506,7 @@ public class Rectangle : Element {
     }
 
     public override Element copy () {
-        return new Rectangle (x, y, width, height, fill, stroke);
+        return new Rectangle (x, y, width, height, fill.copy (), stroke.copy ());
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -510,6 +510,10 @@ public class Rectangle : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
+            return true;
+        }
+
         segment = null;
         var in_x = this.x - tolerance < x && x < this.x + width + tolerance;
         var in_y = this.y - tolerance < y && y < this.y + height + tolerance;

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -436,7 +436,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         bool will_need_separator = false;
 
         // Order that options appear. This should include all option types except separator
-        ContextOptionType[] op_types = {COLOR, ACTION, OPTIONS, TOGGLE};
+        ContextOptionType[] op_types = {COLOR, ACTION, OPTIONS, TOGGLE, DELETER};
 
         foreach (int op_type in op_types) {
             foreach (ContextOption op in elem_options) {
@@ -497,6 +497,17 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
                 button.label = option.label;
                 button.clicked.connect (() => {
                     option.activate ();
+                    menu.popdown ();
+                });
+                menu_layout.append (button);
+                break;
+            case DELETER:
+                var button = new Gtk.Button ();
+                button.add_css_class ("destructive-action");
+                button.label = option.label;
+                button.clicked.connect (() => {
+                    option.activate ();
+                    current_handle = null;
                     menu.popdown ();
                 });
                 menu_layout.append (button);

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -435,7 +435,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         bool needs_separator = false;
         bool will_need_separator = false;
 
-        ContextOptionType[] op_types = {ACTION, OPTIONS, TOGGLE};
+        // Order that options appear. This should include all option types except separator
+        ContextOptionType[] op_types = {COLOR, ACTION, OPTIONS, TOGGLE};
 
         foreach (int op_type in op_types) {
             foreach (ContextOption op in elem_options) {
@@ -515,6 +516,28 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
                 });
                 menu_layout.append (button);
                 break;
+            case COLOR:
+                Gdk.RGBA? rgba = Gdk.RGBA ();
+                option.target.get (option.prop, &rgba);
+                var dialog = new Gtk.ColorDialog () {
+                    with_alpha = true,
+                };
+                var button = new Gtk.ColorDialogButton (dialog) {
+                    rgba = rgba,
+                };
+                button.notify["rgba"].connect (() => {
+                    option.target.begin (option.prop);
+                    option.target.set (option.prop, button.get_rgba ());
+                    option.target.finish (option.prop);
+                });
+                var label = new Gtk.Label (option.label) {
+                    hexpand = true,
+                };
+                var row = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+                row.append (label);
+                row.append (button);
+                menu_layout.append (row);
+                break;
             case OPTIONS:
                 var caption = new Gtk.Label (option.label);
                 menu_layout.append (caption);
@@ -543,6 +566,9 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
                         button.active = true;
                     }
                 }
+                break;
+            default:
+                stderr.printf ("Unknown option type\n");
                 break;
             }
         }


### PR DESCRIPTION
This fixes a few issues with Patterns, including:
* Duplicating an element would have both elements use the same pattern objects, making it impossible to change the pattern for one of them without affecting the other.
* Adding stops couldn't be undone
* Removing stops wasn't possible
* Editing stops was annoying and usually moved the stop
* Changing the type from color or none to gradient started with an empty gradient, which is essentially never wanted
* Code for loading patterns was split between Pattern and Image classes