### PR TITLE
Update to elementary SDK 8

### DIFF
--- a/io.github.sapoturge.froggum.yml
+++ b/io.github.sapoturge.froggum.yml
@@ -1,6 +1,6 @@
 app-id: io.github.sapoturge.froggum
 runtime: io.elementary.Platform
-runtime-version: '7.2'
+runtime-version: '8'
 sdk: io.elementary.Sdk
 command: io.github.sapoturge.froggum
 finish-args:

--- a/src/data/Group.vala
+++ b/src/data/Group.vala
@@ -99,10 +99,6 @@ public class Group : Element, Container {
         return clicked_child (x, y, tolerance, out element, out segment, out handle);
     }
 
-    public Element get_element (Gtk.TreeIter iter) {
-        return new Path ();
-    }
-
     public override Gee.List<ContextOption> options () {
         // Groups have no inherent options.
         return new Gee.ArrayList<ContextOption> ();

--- a/src/widgets/GradientEditor.vala
+++ b/src/widgets/GradientEditor.vala
@@ -90,7 +90,7 @@ public class GradientEditor : Gtk.Box {
             if (sensitive && n == 2) {
                 for (int i = 0; i < pattern.get_n_items(); i++) {
                     Stop stop = (Stop) pattern.get_item (i);
-                    var cx = 15 + (pattern_view.get_allocated_width () - 30) * stop.offset;
+                    var cx = 15 + (pattern_view.get_width () - 30) * stop.offset;
                     if (cx - 10 < x && x < cx + 10) {
                         var dialog = new Gtk.ColorDialog () {
                             title = _("Stop Color"),
@@ -118,7 +118,7 @@ public class GradientEditor : Gtk.Box {
         pattern_view.add_controller(pattern_click_controller);
         pattern_click_controller.pressed.connect ((n, x, y) => {
             if (sensitive) {
-                var offset = (x - 15) / (pattern_view.get_allocated_width () - 30);
+                var offset = (x - 15) / (pattern_view.get_width () - 30);
                 pattern.add_stop (new Stop (offset, pattern.rgba));
             }
         });
@@ -129,7 +129,7 @@ public class GradientEditor : Gtk.Box {
             if (sensitive) {
                 for (int i = 0; i < pattern.get_n_items(); i++) {
                     Stop stop = (Stop) pattern.get_item (i);
-                    var cx = 15 + (pattern_view.get_allocated_width () - 30) * stop.offset;
+                    var cx = 15 + (pattern_view.get_width () - 30) * stop.offset;
                     if (cx - 10 < x && x < cx + 10) {
                         stop.begin ("offset");
                         bound_stop = stop;
@@ -142,11 +142,11 @@ public class GradientEditor : Gtk.Box {
         });
 
         drag_controller.drag_update.connect ((offset_x, offset_y) => {
-            offset = double.min (1, double.max (0, (offset_x + base_offset) / (pattern_view.get_allocated_width () - 30)));
+            offset = double.min (1, double.max (0, (offset_x + base_offset) / (pattern_view.get_width () - 30)));
         });
 
         drag_controller.drag_end.connect ((offset_x, offset_y) => {
-            offset = double.min (1, double.max (0, (offset_x + base_offset) / (pattern_view.get_allocated_width () - 30)));
+            offset = double.min (1, double.max (0, (offset_x + base_offset) / (pattern_view.get_width () - 30)));
             if (stop_binding != null) {
                 stop_binding.unbind ();
                 stop_binding = null;

--- a/src/widgets/PatternChooserDialog.vala
+++ b/src/widgets/PatternChooserDialog.vala
@@ -1,4 +1,4 @@
-public class PatternChooserDialog : Gtk.Dialog {
+public class PatternChooserDialog : Gtk.Window {
     private Pattern _pattern;
     public Pattern pattern {
         get {
@@ -111,8 +111,7 @@ public class PatternChooserDialog : Gtk.Dialog {
         layout.append (gradient_row);
         layout.append (editor);
 
-        var content_area = get_content_area ();
-        content_area.append (layout);
+        child = layout;
     }
 
     private void swap_sensitivity (PatternType new_type) {


### PR DESCRIPTION
This also fixes some deprecations:
- get_allocated_width was replaced with get_width in GradientEditor
- Gtk.Dialog was replaced with Gtk.Window as the base class of PatternChooserDialog
- Leftover TreeModel implementation in Group was removed.