### PR TITLE
Fix searching for new stop location

### DIFF
--- a/src/data/Pattern.vala
+++ b/src/data/Pattern.vala
@@ -315,12 +315,12 @@ public class Pattern : Object, ListModel, Undoable {
 
         var index = stops.size / 2;
         var lower = 0;
-        var upper = stops.size - 1;
+        var upper = stops.size;
         while (upper > lower) {
             if (stops.@get (index).offset < stop.offset) {
                 lower = index + 1;
             } else {
-                upper = index - 1;
+                upper = index;
             }
 
             index = (upper + lower) / 2;


### PR DESCRIPTION
Previously, inserting two stops (such as loading a gradient with two stops) would put the second stop first, regardless of the actual order between them. This now accurately searches the entire range for the correct spot.