### PR TITLE
Improve click detection

### DIFF
--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -172,10 +172,6 @@ public class Circle : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         segment = null;
         if ((Math.sqrt ((x - this.x) * (x - this.x) + (y - this.y) * (y - this.y)) - r).abs () <= tolerance) {
             element = this;

--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -487,13 +487,16 @@ public interface Container : Undoable, Updatable, Transformed {
             selected_child.transform.update_point (x, y, out new_x, out new_y);
             selected_child.transform.update_distance (tolerance, out new_tolerance);
             selected_child.check_controls (new_x, new_y, new_tolerance, out inner_handle);
+            selected_child.clicked (new_x, new_y, new_tolerance, out element, out segment);
             if (inner_handle != null) {
-                selected_child.clicked (new_x, new_y, new_tolerance, out element, out segment); // Just for if a segment was also clicked
                 if (element == null) {
                     element = selected_child;
                 }
 
                 handle = new TransformedHandle (element.title, inner_handle, element.transform);
+                return true;
+            } else if (element != null) {
+                handle = null;
                 return true;
             }
         }

--- a/src/data/Container.vala
+++ b/src/data/Container.vala
@@ -487,7 +487,7 @@ public interface Container : Undoable, Updatable, Transformed {
             selected_child.transform.update_point (x, y, out new_x, out new_y);
             selected_child.transform.update_distance (tolerance, out new_tolerance);
             selected_child.check_controls (new_x, new_y, new_tolerance, out inner_handle);
-            selected_child.clicked (new_x, new_y, new_tolerance, out element, out segment);
+            selected_child.clicked_anywhere (new_x, new_y, new_tolerance, out element, out segment);
             if (inner_handle != null) {
                 if (element == null) {
                     element = selected_child;

--- a/src/data/Element.vala
+++ b/src/data/Element.vala
@@ -127,7 +127,7 @@ public abstract class Element : Object, Undoable, Updatable, Transformed {
 
     public abstract bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment);
 
-    public bool check_standard_clicks (double x, double y, double tolerance, out Element? element, out Segment? segment) {
+    public bool clicked_anywhere (double x, double y, double tolerance, out Element? element, out Segment? segment) {
         if (fill.clicked (x, y, tolerance, out segment)) {
             element = this;
             return true;
@@ -138,8 +138,6 @@ public abstract class Element : Object, Undoable, Updatable, Transformed {
             return true;
         }
 
-        element = null;
-        segment = null;
-        return false;
+        return clicked (x, y, tolerance, out element, out segment);
     }
 }

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -245,10 +245,6 @@ public class Ellipse : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         segment = null;
         var surf = new Cairo.ImageSurface (Cairo.Format.ARGB32, 1, 1);
         var cr = new Cairo.Context (surf);

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -137,10 +137,6 @@ public class Line : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         var dot = (x - start.x) * (end.x - start.x) + (y - start.y) * (end.y - start.y);
         var len_squared = (end.x - start.x) * (end.x - start.x) + (end.y - start.y) * (end.y - start.y);
         var scale = dot / len_squared;

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -298,10 +298,6 @@ public class Path : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         var current_segment = root_segment;
         var first = true;
         while (first || current_segment != root_segment) {

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -233,10 +233,6 @@ public class Polygon : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         segment = null;
 
         var first = true;

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -210,10 +210,6 @@ public class Polyline : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         for (var lsegment = root_segment; lsegment != null; lsegment = lsegment.next) {
             if (lsegment.clicked (x, y, tolerance)) {
                 element = this;

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -522,10 +522,6 @@ public class Rectangle : Element {
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {
-        if (check_standard_clicks (x, y, tolerance, out element, out segment)) {
-            return true;
-        }
-
         segment = null;
         var in_x = this.x - tolerance < x && x < this.x + width + tolerance;
         var in_y = this.y - tolerance < y && y < this.y + height + tolerance;


### PR DESCRIPTION
This fixes to bugs with click detection: all clicks should be applied to the selected element if possible, and clicks where the mouse happens to move should be considered as clicks rather than drags.