### PR TITLE
Bugfix: Fix scrolling and bounds clamping

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -45,10 +45,20 @@ public class FroggumApplication : Gtk.Application {
                 image.redo ();
             }
         });
+
+        var recenter_action = new SimpleAction ("action_recenter", null);
+        recenter_action.activate.connect (() => {
+            var tab = notebook.get_selected_page ();
+            var editor = tab.child;
+            if (editor is EditorView) {
+                editor.recenter ();
+            }
+        });
         
         actions = new SimpleActionGroup ();
         actions.add_action (undo_action);
         actions.add_action (redo_action);
+        actions.add_action (recenter_action);
         
         set_accels_for_action ("froggum.action_undo", {"<Control>Z", null});
         set_accels_for_action ("froggum.action_redo", {"<Control>Y", null});
@@ -145,6 +155,12 @@ public class FroggumApplication : Gtk.Application {
 
         header.pack_start (undo_button);
         header.pack_start (redo_button);
+
+        var center_button = new Gtk.Button.from_icon_name ("zoom-fit-best");
+        center_button.action_name = "froggum.action_recenter";
+        center_button.tooltip_text = _("Recenter image");
+
+        header.pack_start (center_button);
 
         main_window.set_titlebar (header);
 

--- a/src/widgets/EditorView.vala
+++ b/src/widgets/EditorView.vala
@@ -327,4 +327,8 @@ public class EditorView : Gtk.Box {
         hexpand = true;
         vexpand = true;
     }
+
+    public void recenter () {
+        viewport.recenter ();
+    }
 }

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -10,6 +10,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
     private double _zoom = 1;
     // Used for tracking when zooming with a touchpad
     private double base_zoom;
+    private bool zooming = false;
+    private uint zoom_stop_callback;
 
     private int width = 0;
     private int height = 0;
@@ -69,8 +71,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             return (double) _scroll_x;
         }
         set {
-            // _scroll_x = (int) value; // This is set in the callback from setting horizontal.value
-            horizontal.lower = double.min (-value - width / 2, 0);
+            _scroll_x = (int) value;
+            horizontal.lower = double.min (-value - width / 2, horizontal.lower);
             horizontal.upper = double.max (-value + width / 2, image.width * zoom);
             horizontal.value = -value - width / 2;
         }
@@ -81,8 +83,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             return (double) _scroll_y;
         }
         set {
-            // _scroll_y = (int) value; // This is set in the callback from setting vertical.value
-            vertical.lower = double.min (-value - height / 2, 0);
+            _scroll_y = (int) value;
+            vertical.lower = double.min (-value - height / 2, vertical.lower);
             vertical.upper = double.max (-value + height / 2, image.height * zoom);
             vertical.value = -value - height / 2;
         }
@@ -116,8 +118,10 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             }
             // Bind events
             horizontal.value_changed.connect (() => {
-                _scroll_x = -((int) horizontal.value + width / 2);
-                queue_draw ();
+                if (!zooming) {
+                    _scroll_x = -((int) horizontal.value + width / 2);
+                    queue_draw ();
+                }
             });
         }
     }
@@ -141,8 +145,10 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             }
             // Bind events
             vertical.value_changed.connect (() => {
-                _scroll_y = -((int) vertical.value + height / 2);
-                queue_draw ();
+                if (!zooming) {
+                    _scroll_y = -((int) vertical.value + height / 2);
+                    queue_draw ();
+                }
             });
         }
     }
@@ -348,10 +354,29 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         var zoom_controller = new Gtk.GestureZoom ();
         add_controller (zoom_controller);
         zoom_controller.begin.connect (() => {
+            if (zoom_stop_callback != 0) {
+                Source.remove (zoom_stop_callback);
+            }
+
+            zooming = true;
             base_zoom = zoom;
         });
         zoom_controller.scale_changed.connect ((scale) => {
             update_zoom (scale * base_zoom);
+        });
+        zoom_controller.end.connect (() => {
+            // The delay needs to be long enough for the scrolled window's deceleration to finish
+            zoom_stop_callback = Timeout.add(1000, () => {
+                zooming = false;
+                zoom_stop_callback = 0;
+                horizontal.lower = double.min (-scroll_x - width / 2, 0);
+                horizontal.upper = double.max (-scroll_x + width / 2, image.width * zoom);
+                vertical.lower = double.min (-scroll_y - height / 2, 0);
+                vertical.upper = double.max (-scroll_y + height / 2, image.height * zoom);
+                // Update the adjustment values for the scrolled window
+                scroll_x = scroll_x;
+                scroll_y = scroll_y;
+            });
         });
 
         resize.connect ((width, height) => {

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -69,8 +69,10 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             return (double) _scroll_x;
         }
         set {
-            _scroll_x = (int) value;
-            horizontal.value = -double.min (scroll_x + width / 2, 0);
+            // _scroll_x = (int) value; // This is set in the callback from setting horizontal.value
+            horizontal.lower = double.min (-value - width / 2, 0);
+            horizontal.upper = double.max (-value + width / 2, image.width * zoom);
+            horizontal.value = -value - width / 2;
         }
     }
 
@@ -79,8 +81,10 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             return (double) _scroll_y;
         }
         set {
-            _scroll_y = (int) value;
-            vertical.value = double.max (scroll_y + height / 2, 0);
+            // _scroll_y = (int) value; // This is set in the callback from setting vertical.value
+            vertical.lower = double.min (-value - height / 2, 0);
+            vertical.upper = double.max (-value + height / 2, image.height * zoom);
+            vertical.value = -value - height / 2;
         }
     }
 
@@ -90,8 +94,6 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         }
         set {
             _zoom = value;
-            hadjustment.upper = image.width * _zoom;
-            vertical.upper = image.height * _zoom;
         }
     }
 
@@ -115,6 +117,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             // Bind events
             horizontal.value_changed.connect (() => {
                 _scroll_x = -((int) horizontal.value + width / 2);
+                queue_draw ();
             });
         }
     }
@@ -131,7 +134,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             // Set values
             if (image != null) {
                 vertical.lower = 0;
-                vertical.upper = image.height;
+                vertical.upper = image.height * zoom;
                 vertical.page_size = height;
                 vertical.page_increment = 1;
                 vertical.step_increment = 1;
@@ -139,6 +142,7 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             // Bind events
             vertical.value_changed.connect (() => {
                 _scroll_y = -((int) vertical.value + height / 2);
+                queue_draw ();
             });
         }
     }
@@ -378,11 +382,10 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
             tutorial.next_step ();
         }
 
-        scroll_x *= new_zoom;
-        scroll_x /= zoom;
-        scroll_y *= new_zoom;
-        scroll_y /= zoom;
+        var old_zoom = zoom;
         zoom = new_zoom;
+        scroll_x = scroll_x * new_zoom / old_zoom;
+        scroll_y = scroll_y * new_zoom / old_zoom;
 
         position_tutorial ();
         queue_draw ();

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -628,4 +628,9 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
 
         menu.popup ();
     }
+
+    public void recenter () {
+        scroll_x = -image.width * zoom / 2;
+        scroll_y = -image.height * zoom / 2;
+    }
 }

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -72,8 +72,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         }
         set {
             _scroll_x = (int) value;
-            horizontal.lower = double.min (-value - width / 2, horizontal.lower);
-            horizontal.upper = double.max (-value + width / 2, image.width * zoom);
+            horizontal.lower = double.min (-value, 0) - width / 2;
+            horizontal.upper = double.max (-value, image.width * zoom) + width / 2;
             horizontal.value = -value - width / 2;
         }
     }
@@ -84,8 +84,8 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
         }
         set {
             _scroll_y = (int) value;
-            vertical.lower = double.min (-value - height / 2, vertical.lower);
-            vertical.upper = double.max (-value + height / 2, image.height * zoom);
+            vertical.lower = double.min (-value, 0) - height / 2;
+            vertical.upper = double.max (-value, image.height * zoom) + height / 2;
             vertical.value = -value - height / 2;
         }
     }

--- a/src/widgets/Viewport.vala
+++ b/src/widgets/Viewport.vala
@@ -1,10 +1,16 @@
 public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
-    private double _scroll_x;
-    private double _scroll_y;
+    // Pixel offset from center to start drawing icon
+    private int _scroll_x;
+    private int _scroll_y;
+
     private double base_x;
     private double base_y;
+
+    // Scale factor for viewing (4 = 4x magnification; cannot be less than 1)
     private double _zoom = 1;
+    // Used for tracking when zooming with a touchpad
     private double base_zoom;
+
     private int width = 0;
     private int height = 0;
     private Point base_point;
@@ -60,20 +66,20 @@ public class Viewport : Gtk.DrawingArea, Gtk.Scrollable {
 
     private double scroll_x {
         get {
-            return _scroll_x;
+            return (double) _scroll_x;
         }
         set {
-            _scroll_x = value;
+            _scroll_x = (int) value;
             horizontal.value = -double.min (scroll_x + width / 2, 0);
         }
     }
 
     private double scroll_y {
         get {
-            return _scroll_y;
+            return (double) _scroll_y;
         }
         set {
-            _scroll_y = value;
+            _scroll_y = (int) value;
             vertical.value = double.max (scroll_y + height / 2, 0);
         }
     }


### PR DESCRIPTION
Previously, the viewport would prevent scrolling inside the top left corner of the image, preventing viewing the bottom or right sides. This is backwards, and this update fixes it so scrolling is allowed anywhere inside the image, and panning beyond the borders can be done at any time. It also ensures that at least the top left corner is aligned to the pixel grid, ensuring a proper view when fully zoomed out.