### PR TITLE
Bugfix: Copy transforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
       # Builds your flatpak manifest using the Flatpak Builder action
     - uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
 
       # Builds your flatpak manifest using the Flatpak Builder action
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
         # This is the name of the Bundle file we're building and can be anything you like
         bundle: froggum.flatpak

--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -31,7 +31,7 @@ public class Circle : Element {
         }
     }
 
-    public Circle (double x, double y, double r, Pattern fill, Pattern stroke, string? title = null) {
+    public Circle (double x, double y, double r, Pattern fill, Pattern stroke, string? title = null, Transform? transform = null) {
         this.x = x;
         this.y = y;
         this.r = r;
@@ -45,7 +45,12 @@ public class Circle : Element {
             this.title = title;
         }
 
-        this.transform = new Transform.identity ();
+        if (transform == null) {
+            this.transform = new Transform.identity ();
+        } else {
+            this.transform = transform;
+            transform_enabled = transform.is_identity ();
+        }
 
         setup_signals ();
     }
@@ -161,7 +166,7 @@ public class Circle : Element {
     }
 
     public override Element copy () {
-        return new Circle (x, y, r, fill.copy (), stroke.copy ());
+        return new Circle (x, y, r, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Circle.vala
+++ b/src/data/Circle.vala
@@ -49,7 +49,7 @@ public class Circle : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -89,6 +89,7 @@ public class Ellipse : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
+            transform_enabled = transform.is_identity ();
         }
 
         setup_signals ();
@@ -253,7 +254,7 @@ public class Ellipse : Element {
     }
 
     public override Element copy () {
-        return new Ellipse (cx, cy, rx, ry, fill.copy (), stroke.copy ());
+        return new Ellipse (cx, cy, rx, ry, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {

--- a/src/data/Ellipse.vala
+++ b/src/data/Ellipse.vala
@@ -89,7 +89,7 @@ public class Ellipse : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -21,7 +21,7 @@ public class Line : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Line.vala
+++ b/src/data/Line.vala
@@ -5,7 +5,7 @@ public class Line : Element {
     private Point last_start;
     private Point last_end;
 
-    public Line (double x1, double y1, double x2, double y2, Pattern stroke, string? title = null) {
+    public Line (double x1, double y1, double x2, double y2, Pattern stroke, string? title = null, Transform? transform = null) {
         this.start = { x1, y1 };
         this.end = { x2, y2 };
         this.fill = new Pattern.none ();
@@ -17,7 +17,12 @@ public class Line : Element {
             this.title = title;
         }
 
-        this.transform = new Transform.identity ();
+        if (transform == null) {
+            this.transform = new Transform.identity ();
+        } else {
+            this.transform = transform;
+            transform_enabled = transform.is_identity ();
+        }
 
         setup_signals ();
     }
@@ -126,7 +131,7 @@ public class Line : Element {
     }
 
     public override Element copy () {
-        return new Line (start.x, start.y, end.x, end.y, stroke.copy ());
+        return new Line (start.x, start.y, end.x, end.y, stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -16,7 +16,7 @@ public class Path : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         visible = true;

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -16,6 +16,7 @@ public class Path : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
+            transform_enabled = transform.is_identity ();
         }
 
         visible = true;
@@ -147,7 +148,7 @@ public class Path : Element {
             current_segment = current_segment.next;
         }
 
-        return new Path.with_pattern (new_segments, fill.copy (), stroke.copy (), title);
+        return new Path.with_pattern (new_segments, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public void split_segment (PathSegment segment) {

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -16,6 +16,7 @@ public class Polygon : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
+            transform_enabled = transform.is_identity ();
         }
 
         setup_signals ();
@@ -206,7 +207,7 @@ public class Polygon : Element {
             first = false;
         }
 
-        return new Polygon (points, fill.copy (), stroke.copy (), "Copy of " + title, transform);
+        return new Polygon (points, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Polygon.vala
+++ b/src/data/Polygon.vala
@@ -16,7 +16,7 @@ public class Polygon : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -16,6 +16,7 @@ public class Polyline : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
+            transform_enabled = transform.is_identity ();
         }
 
         setup_signals ();
@@ -203,7 +204,7 @@ public class Polyline : Element {
             points += segment.end;
         }
 
-        return new Polyline (points, fill.copy (), stroke.copy (), "Copy of " + title, transform);
+        return new Polyline (points, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool check_controls (double x, double y, double tolerance, out Handle? handle) {

--- a/src/data/Polyline.vala
+++ b/src/data/Polyline.vala
@@ -16,7 +16,7 @@ public class Polyline : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -162,7 +162,7 @@ public class Rectangle : Element {
         }
     }
 
-    public Rectangle (double x, double y, double width, double height, Pattern fill, Pattern stroke, string? title = null) {
+    public Rectangle (double x, double y, double width, double height, Pattern fill, Pattern stroke, string? title = null, Transform? transform = null) {
         this.x = x;
         this.y = y;
         this.width = width;
@@ -176,7 +176,12 @@ public class Rectangle : Element {
             this.title = title;
         }
 
-        this.transform = new Transform.identity ();
+        if (transform == null) {
+            this.transform = new Transform.identity ();
+        } else {
+            this.transform = transform;
+            transform_enabled = transform.is_identity ();
+        }
 
         setup_signals ();
 
@@ -528,7 +533,7 @@ public class Rectangle : Element {
     }
 
     public override Element copy () {
-        return new Rectangle (x, y, width, height, fill.copy (), stroke.copy ());
+        return new Rectangle (x, y, width, height, fill.copy (), stroke.copy (), "Copy of " + title, transform.copy ());
     }
 
     public override bool clicked (double x, double y, double tolerance, out Element? element, out Segment? segment) {

--- a/src/data/Rectangle.vala
+++ b/src/data/Rectangle.vala
@@ -180,7 +180,7 @@ public class Rectangle : Element {
             this.transform = new Transform.identity ();
         } else {
             this.transform = transform;
-            transform_enabled = transform.is_identity ();
+            transform_enabled = !transform.is_identity ();
         }
 
         setup_signals ();

--- a/src/data/Transform.vala
+++ b/src/data/Transform.vala
@@ -509,10 +509,10 @@ public class Transform : Object, Undoable {
     }
 
     public bool is_identity () {
-        return (translate_x == 0 && translate_y == 0
-             && scale_x == 1 && scale_y == 1
-             && angle == 0
-             && skew == 0);
+        return (double_is_zero(translate_x) && double_is_zero(translate_y)
+             && double_is_zero(scale_x-1) && double_is_zero(scale_y-1)
+             && double_is_zero(angle)
+             && double_is_zero(skew));
     }
 
     private void update_matrix () {
@@ -724,4 +724,9 @@ public class Transform : Object, Undoable {
         new_transform.update_matrix ();
         return new_transform;
     }
+}
+
+private bool double_is_zero (double val) {
+    const double EPSILON = 128*double.EPSILON;
+    return val.abs() <= EPSILON;
 }

--- a/src/data/Transform.vala
+++ b/src/data/Transform.vala
@@ -712,4 +712,16 @@ public class Transform : Object, Undoable {
         new_matrix.multiply(new_matrix, base_transform.matrix);
         return new Transform.from_matrix(new_matrix);
     }
+
+    public Transform copy () {
+        var new_transform = new Transform.identity ();
+        new_transform.translate_x = translate_x;
+        new_transform.translate_y = translate_y;
+        new_transform.scale_x = scale_x;
+        new_transform.scale_y = scale_y;
+        new_transform.angle = angle;
+        new_transform.skew = skew;
+        new_transform.update_matrix ();
+        return new_transform;
+    }
 }


### PR DESCRIPTION
When duplicating elements, ~they would share the same transform object, making it impossible to transform them individually~ the new object would have no transform applied. This gives each one a separate (initially identical) transform object.