### PR TITLE
Refresh error bar after reloading image

### DIFF
--- a/src/widgets/EditorView.vala
+++ b/src/widgets/EditorView.vala
@@ -446,5 +446,9 @@ public class EditorView : Gtk.Box, ErrorReporter {
             image.reload ();
             break;
         }
+
+        error_bar.error = image.error;
+        error_from_image = true;
+        allow_edits = image.error == null;
     }
 }


### PR DESCRIPTION
Previously, the error bar would only update if reloading brought up a new error; it would stay as it was if no errors were found. This makes the error bar disappear properly when the reloaded image has no errors.