### PR TITLE
More path segments

### DIFF
--- a/src/data/Parser.vala
+++ b/src/data/Parser.vala
@@ -101,9 +101,11 @@ public class Parser : Object {
     }
 
     public bool get_int (out int value) {
+        var backup_index = index;
         bool negative = match ("-");
         if (!get_digit (out value, 10, false)) {
             value = 0;
+            index = backup_index;
             return false;
         }
 
@@ -121,6 +123,7 @@ public class Parser : Object {
     }
 
     public bool get_float (out float value) {
+        var backup_index = index;
         float multiplier = 1;
         if (match ("-")) {
             multiplier = -1;
@@ -131,6 +134,7 @@ public class Parser : Object {
         value = base_val * multiplier;
         var has_decimal_part = match (".", false);
         if (!(has_int_part || has_decimal_part)) {
+            index = backup_index;
             return false;
         }
 
@@ -144,6 +148,7 @@ public class Parser : Object {
     }
 
     public bool get_double (out double value) {
+        var backup_index = index;
         double multiplier = 1;
         if (match ("-")) {
             multiplier = -1;
@@ -154,6 +159,7 @@ public class Parser : Object {
         value = base_val * multiplier;
         var has_decimal_part = match (".", false);
         if (!(has_int_part || has_decimal_part)) {
+            index = backup_index;
             return false;
         }
 

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -132,6 +132,34 @@ public class Path : Element {
                 current_x = x;
                 current_y = y;
                 parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
+            } else if (parser.match ("S")) {
+                double x1, y1, x2, y2, x, y;
+                if (!parser.get_double (out x2)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out y2)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out x)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out y)) {
+                    loaded_successfully = false;
+                    break;
+                }
+
+                x1 = current_x;
+                y1 = current_y;
+
+                if (segments.length > 0 && segments[segments.length-1].segment_type == CURVE) {
+                    x1 = 2 * current_x - segments[segments.length-1].p2.x;
+                    y1 = 2 * current_y - segments[segments.length-1].p2.y;
+                }
+
+                segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
+                current_x = x;
+                current_y = y;
+                parsed.append_printf ("S %f %f %f %f ", x2, y2, x, y);
             } else if (parser.match ("Q")) {
                 double x1, y1, x, y;
                 if (!parser.get_double (out x1)) {
@@ -152,6 +180,28 @@ public class Path : Element {
                 current_x = x;
                 current_y = y;
                 parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
+            } else if (parser.match ("T")) {
+                double x1, y1, x, y;
+                if (!parser.get_double (out x)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out y)) {
+                    loaded_successfully = false;
+                    break;
+                }
+
+                x1 = current_x;
+                y1 = current_y;
+
+                if (segments.length > 0 && segments[segments.length-1].segment_type == QUADRATIC) {
+                    x1 = 2 * current_x - segments[segments.length - 1].p1.x;
+                    y1 = 2 * current_y - segments[segments.length - 1].p1.y;
+                }
+
+                segments += new PathSegment.quadratic (x1, y1, x, y);
+                current_x = x;
+                current_y = y;
+                parsed.append_printf ("T %f, %f ", x, y);
             } else if (parser.match ("A")) {
                 double rx, ry, angle;
                 int large_arc, sweep;

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -20,7 +20,7 @@ public class Path : Element {
         }
 
         visible = true;
-        set_segments (segments);
+        set_segments (new Gee.ArrayList<PathSegment>.wrap (segments));
         setup_signals ();
     }
 
@@ -42,7 +42,7 @@ public class Path : Element {
     }
 
     private void parse_string (string description, Gee.Queue<Error> errors) {
-        var segments = new PathSegment[] {};
+        var segments = new Gee.ArrayList<PathSegment> ();
         var parser = new Parser (description);
         var parsed = new StringBuilder ();
         var loaded_first = false;
@@ -51,8 +51,9 @@ public class Path : Element {
         double current_x = 0;
         double current_y = 0;
         bool loaded_successfully = true;
-        while (!parser.empty ()) {
-            if (parser.match("M")) {
+        while (loaded_successfully && !parser.empty ()) {
+            switch (parser.get_string (1)) {
+            case "M":
                 if (loaded_first) {
                     // Paths with disconnected segments aren't supported yet.
                     loaded_successfully = false;
@@ -60,283 +61,60 @@ public class Path : Element {
                 }
 
                 loaded_first = true;
-
-                if (!parser.get_double (out start_x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out start_y)) {
-                    loaded_successfully = false;
-                    break;
-                }
-
-                current_x = start_x;
-                current_y = start_y;
-                parsed.append_printf ("M %f, %f ", start_x, start_y);
-
-                // Additional coordinates after an 'M' command are lines.
-                double x, y;
-                while (parser.get_double (out x)) {
-                    if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    segments += new PathSegment.line (x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("L %f, %f ", x, y);
-                }
-                    
-                if (!loaded_successfully) {
-                    break;
-                }
-            } else if (parser.match ("L")) {
-                double x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out x)) {
-                    if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    segments += new PathSegment.line (x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("L %f, %f ", x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("H")) {
-                double x;
-                bool loaded_once = false;
-                while (parser.get_double (out x)) {
-                    segments += new PathSegment.line (x, current_y);
-                    current_x = x;
-                    parsed.append_printf ("H %f ", x);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("V")) {
-                double y;
-                bool loaded_once = false;
-                while (parser.get_double (out y)) {
-                    segments += new PathSegment.line (current_x, y);
-                    current_y = y;
-                    parsed.append_printf ("V %f ", y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("C")) {
-                double x1, x2, y1, y2, x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out x1)) {
-                    if (!parser.get_double (out y1)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out x2)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out y2)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out x)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("S")) {
-                double x1, y1, x2, y2, x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out x2)) {
-                    if (!parser.get_double (out y2)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out x)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    x1 = current_x;
-                    y1 = current_y;
-
-                    if (segments.length > 0 && segments[segments.length-1].segment_type == CURVE) {
-                        x1 = 2 * current_x - segments[segments.length-1].p2.x;
-                        y1 = 2 * current_y - segments[segments.length-1].p2.y;
-                    }
-
-                    segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("S %f %f %f %f ", x2, y2, x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("Q")) {
-                double x1, y1, x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out x1)) {
-                    if (!parser.get_double (out y1)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out x)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    segments += new PathSegment.quadratic (x1, y1, x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("T")) {
-                double x1, y1, x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out x)) {
-                    if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    x1 = current_x;
-                    y1 = current_y;
-
-                    if (segments.length > 0 && segments[segments.length-1].segment_type == QUADRATIC) {
-                        x1 = 2 * current_x - segments[segments.length - 1].p1.x;
-                        y1 = 2 * current_y - segments[segments.length - 1].p1.y;
-                    }
-
-                    segments += new PathSegment.quadratic (x1, y1, x, y);
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("T %f, %f ", x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("A")) {
-                double rx, ry, angle;
-                int large_arc, sweep;
-                double x, y;
-                bool loaded_once = false;
-                while (parser.get_double (out rx)) {
-                    if (!parser.get_double (out ry)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out angle)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_int (out large_arc)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_int (out sweep)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out x)) {
-                        loaded_successfully = false;
-                        break;
-                    } else if (!parser.get_double (out y)) {
-                        loaded_successfully = false;
-                        break;
-                    }
-
-                    angle = angle * Math.PI / 180;
-
-                    var x1 = (current_x - x) / 2 * Math.cos (angle) + Math.sin (angle) * (current_y - y) / 2;
-                    var y1 = -Math.sin (angle) * (current_x - x) / 2 + Math.cos (angle) * (current_y - y) / 2;
-                    var dt = (x1 * x1) / ( rx * rx) + (y1 * y1) / (ry * ry);
-                    if (dt > 1) {
-                        rx = rx * Math.sqrt (dt);
-                        ry = ry * Math.sqrt (dt);
-                    }
-                    var coefficient = Math.sqrt ((rx * rx * ry * ry - rx * rx * y1 * y1 - ry * ry * x1 * x1) / (rx * rx * y1 * y1 + ry * ry * x1 * x1));
-                    if (large_arc == sweep) {
-                        coefficient = -coefficient;
-                    }
-                    var cx1 = coefficient * rx * y1 / ry;
-                    var cy1 = -coefficient * ry * x1 / rx;
-                    var cx = cx1 * Math.cos (angle) - cy1 * Math.sin (angle) + (current_x + x) / 2;
-                    var cy = cx1 * Math.sin (angle) + cy1 * Math.cos (angle) + (current_y + y) / 2;
-                    segments += new PathSegment.arc (x, y, cx, cy, rx, ry, angle, (sweep == 0));
-                    current_x = x;
-                    current_y = y;
-                    parsed.append_printf ("A %f, %f, %f, %d, %d, %f, %f ", rx, ry, angle, large_arc, sweep, x, y);
-                    loaded_once = true;
-                }
-
-                if (!loaded_once || !loaded_successfully) {
-                    loaded_successfully = false;
-                    break;
-                }
-            } else if (parser.match ("Z")) {
+                loaded_successfully = PathSegment.load_moves (parser, parsed, segments, out start_x, out start_y, ref current_x, ref current_y);
+                break;
+            case "L":
+                loaded_successfully = PathSegment.load_lines (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "H":
+                loaded_successfully = PathSegment.load_horizontal_lines (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "V":
+                loaded_successfully = PathSegment.load_vertical_lines (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "C":
+                loaded_successfully = PathSegment.load_curves (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "S":
+                loaded_successfully = PathSegment.load_smooth_curves (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "Q":
+                loaded_successfully = PathSegment.load_quadratics (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "T":
+                loaded_successfully = PathSegment.load_smooth_quadratics (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "A":
+                loaded_successfully = PathSegment.load_arcs (parser, parsed, segments, ref current_x, ref current_y);
+                break;
+            case "Z":
                 // Ends the path, back to the beginning.
                 if (start_x != current_x || start_y != current_y) {
-                    segments += new PathSegment.line (start_x, start_y);
+                    segments.add (new PathSegment.line (start_x, start_y));
                 }
 
                 parsed.append_printf ("Z ");
-            } else {
+                break;
+            default:
                 loaded_successfully = false;
                 break;
             }
+
+            parser.skip_whitespace ();
         }
 
-        if (segments.length == 0) {
+        if (segments.is_empty) {
             // Something went very wrong in loading.
             // This seems like a reasonable default.
-            segments += new PathSegment.line (current_x, current_y);
-            segments += new PathSegment.line (start_x, start_y);
+            segments.add (new PathSegment.line (current_x, current_y));
+            segments.add (new PathSegment.line (start_x, start_y));
             parsed.append_printf ("L %f, %f Z", current_x, current_y);
             loaded_successfully = false;
         }
 
         if (current_x != start_x || current_y != start_y) {
             // Open paths should be supported eventually, but aren't yet.
-            segments += new PathSegment.line (start_x, start_y);
+            segments.add (new PathSegment.line (start_x, start_y));
             parsed.append ("Z");
             loaded_successfully = false;
         }
@@ -348,12 +126,12 @@ public class Path : Element {
         set_segments (segments);
     }
 
-    private void set_segments (PathSegment[] segments) {
+    private void set_segments (Gee.List<PathSegment> segments) {
         root_segment = segments[0];
-        for (int i = 0; i < segments.length; i++) {
+        for (int i = 0; i < segments.size; i++) {
             segments[i].notify.connect (() => { update (); });
             segments[i].add_command.connect ((c) => { add_command (c); });
-            segments[i].next = segments[(i + 1) % segments.length];
+            segments[i].next = segments[(i + 1) % segments.size];
             segments[i].request_split.connect ((s) => {
                     split_segment((PathSegment) s);
             });

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -72,184 +72,246 @@ public class Path : Element {
                 current_x = start_x;
                 current_y = start_y;
                 parsed.append_printf ("M %f, %f ", start_x, start_y);
+
+                // Additional coordinates after an 'M' command are lines.
+                double x, y;
+                while (parser.get_double (out x)) {
+                    if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    segments += new PathSegment.line (x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("L %f, %f ", x, y);
+                }
+                    
+                if (!loaded_successfully) {
+                    break;
+                }
             } else if (parser.match ("L")) {
                 double x, y;
-                if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x)) {
+                    if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    segments += new PathSegment.line (x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("L %f, %f ", x, y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once || !loaded_successfully) {
                     loaded_successfully = false;
                     break;
                 }
-
-                segments += new PathSegment.line (x, y);
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("L %f, %f ", x, y);
             } else if (parser.match ("H")) {
                 double x;
-                if (!parser.get_double (out x)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x)) {
+                    segments += new PathSegment.line (x, current_y);
+                    current_x = x;
+                    parsed.append_printf ("H %f ", x);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once) {
                     loaded_successfully = false;
                     break;
                 }
-
-                segments += new PathSegment.line (x, current_y);
-                current_x = x;
-                parsed.append_printf ("H %f ", x);
             } else if (parser.match ("V")) {
                 double y;
-                if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out y)) {
+                    segments += new PathSegment.line (current_x, y);
+                    current_y = y;
+                    parsed.append_printf ("V %f ", y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once) {
                     loaded_successfully = false;
                     break;
                 }
-
-                segments += new PathSegment.line (current_x, y);
-                current_y = y;
-                parsed.append_printf ("V %f ", y);
             } else if (parser.match ("C")) {
                 double x1, x2, y1, y2, x, y;
-                if (!parser.get_double (out x1)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y1)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out x2)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y2)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x1)) {
+                    if (!parser.get_double (out y1)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out x2)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out y2)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out x)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once || !loaded_successfully) {
                     loaded_successfully = false;
                     break;
                 }
-
-                segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
             } else if (parser.match ("S")) {
                 double x1, y1, x2, y2, x, y;
-                if (!parser.get_double (out x2)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y2)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x2)) {
+                    if (!parser.get_double (out y2)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out x)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    x1 = current_x;
+                    y1 = current_y;
+
+                    if (segments.length > 0 && segments[segments.length-1].segment_type == CURVE) {
+                        x1 = 2 * current_x - segments[segments.length-1].p2.x;
+                        y1 = 2 * current_y - segments[segments.length-1].p2.y;
+                    }
+
+                    segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("S %f %f %f %f ", x2, y2, x, y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once || !loaded_successfully) {
                     loaded_successfully = false;
                     break;
                 }
-
-                x1 = current_x;
-                y1 = current_y;
-
-                if (segments.length > 0 && segments[segments.length-1].segment_type == CURVE) {
-                    x1 = 2 * current_x - segments[segments.length-1].p2.x;
-                    y1 = 2 * current_y - segments[segments.length-1].p2.y;
-                }
-
-                segments += new PathSegment.curve (x1, y1, x2, y2, x, y);
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("S %f %f %f %f ", x2, y2, x, y);
             } else if (parser.match ("Q")) {
                 double x1, y1, x, y;
-                if (!parser.get_double (out x1)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y1)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x1)) {
+                    if (!parser.get_double (out y1)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out x)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    segments += new PathSegment.quadratic (x1, y1, x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once || !loaded_successfully) {
                     loaded_successfully = false;
                     break;
                 }
-
-                segments += new PathSegment.quadratic (x1, y1, x, y);
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
             } else if (parser.match ("T")) {
                 double x1, y1, x, y;
-                if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
+                bool loaded_once = false;
+                while (parser.get_double (out x)) {
+                    if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    x1 = current_x;
+                    y1 = current_y;
+
+                    if (segments.length > 0 && segments[segments.length-1].segment_type == QUADRATIC) {
+                        x1 = 2 * current_x - segments[segments.length - 1].p1.x;
+                        y1 = 2 * current_y - segments[segments.length - 1].p1.y;
+                    }
+
+                    segments += new PathSegment.quadratic (x1, y1, x, y);
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("T %f, %f ", x, y);
+                    loaded_once = true;
+                }
+
+                if (!loaded_once || !loaded_successfully) {
                     loaded_successfully = false;
                     break;
                 }
-
-                x1 = current_x;
-                y1 = current_y;
-
-                if (segments.length > 0 && segments[segments.length-1].segment_type == QUADRATIC) {
-                    x1 = 2 * current_x - segments[segments.length - 1].p1.x;
-                    y1 = 2 * current_y - segments[segments.length - 1].p1.y;
-                }
-
-                segments += new PathSegment.quadratic (x1, y1, x, y);
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("T %f, %f ", x, y);
             } else if (parser.match ("A")) {
                 double rx, ry, angle;
                 int large_arc, sweep;
                 double x, y;
-                if (!parser.get_double (out rx)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out ry)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out angle)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_int (out large_arc)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_int (out sweep)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out x)) {
-                    loaded_successfully = false;
-                    break;
-                } else if (!parser.get_double (out y)) {
-                    loaded_successfully = false;
-                    break;
+                bool loaded_once = false;
+                while (parser.get_double (out rx)) {
+                    if (!parser.get_double (out ry)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out angle)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_int (out large_arc)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_int (out sweep)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out x)) {
+                        loaded_successfully = false;
+                        break;
+                    } else if (!parser.get_double (out y)) {
+                        loaded_successfully = false;
+                        break;
+                    }
+
+                    angle = angle * Math.PI / 180;
+
+                    var x1 = (current_x - x) / 2 * Math.cos (angle) + Math.sin (angle) * (current_y - y) / 2;
+                    var y1 = -Math.sin (angle) * (current_x - x) / 2 + Math.cos (angle) * (current_y - y) / 2;
+                    var dt = (x1 * x1) / ( rx * rx) + (y1 * y1) / (ry * ry);
+                    if (dt > 1) {
+                        rx = rx * Math.sqrt (dt);
+                        ry = ry * Math.sqrt (dt);
+                    }
+                    var coefficient = Math.sqrt ((rx * rx * ry * ry - rx * rx * y1 * y1 - ry * ry * x1 * x1) / (rx * rx * y1 * y1 + ry * ry * x1 * x1));
+                    if (large_arc == sweep) {
+                        coefficient = -coefficient;
+                    }
+                    var cx1 = coefficient * rx * y1 / ry;
+                    var cy1 = -coefficient * ry * x1 / rx;
+                    var cx = cx1 * Math.cos (angle) - cy1 * Math.sin (angle) + (current_x + x) / 2;
+                    var cy = cx1 * Math.sin (angle) + cy1 * Math.cos (angle) + (current_y + y) / 2;
+                    segments += new PathSegment.arc (x, y, cx, cy, rx, ry, angle, (sweep == 0));
+                    current_x = x;
+                    current_y = y;
+                    parsed.append_printf ("A %f, %f, %f, %d, %d, %f, %f ", rx, ry, angle, large_arc, sweep, x, y);
+                    loaded_once = true;
                 }
 
-                angle = angle * Math.PI / 180;
-
-                var x1 = (current_x - x) / 2 * Math.cos (angle) + Math.sin (angle) * (current_y - y) / 2;
-                var y1 = -Math.sin (angle) * (current_x - x) / 2 + Math.cos (angle) * (current_y - y) / 2;
-                var dt = (x1 * x1) / ( rx * rx) + (y1 * y1) / (ry * ry);
-                if (dt > 1) {
-                    rx = rx * Math.sqrt (dt);
-                    ry = ry * Math.sqrt (dt);
+                if (!loaded_once || !loaded_successfully) {
+                    loaded_successfully = false;
+                    break;
                 }
-                var coefficient = Math.sqrt ((rx * rx * ry * ry - rx * rx * y1 * y1 - ry * ry * x1 * x1) / (rx * rx * y1 * y1 + ry * ry * x1 * x1));
-                if (large_arc == sweep) {
-                    coefficient = -coefficient;
-                }
-                var cx1 = coefficient * rx * y1 / ry;
-                var cy1 = -coefficient * ry * x1 / rx;
-                var cx = cx1 * Math.cos (angle) - cy1 * Math.sin (angle) + (current_x + x) / 2;
-                var cy = cx1 * Math.sin (angle) + cy1 * Math.cos (angle) + (current_y + y) / 2;
-                segments += new PathSegment.arc (x, y, cx, cy, rx, ry, angle, (sweep == 0));
-                current_x = x;
-                current_y = y;
-                parsed.append_printf ("A %f, %f, %f, %d, %d, %f, %f ", rx, ry, angle, large_arc, sweep, x, y);
             } else if (parser.match ("Z")) {
                 // Ends the path, back to the beginning.
                 if (start_x != current_x || start_y != current_y) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -103,6 +103,26 @@ public class Path : Element {
                 current_x = x;
                 current_y = y;
                 parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
+            } else if (parser.match ("Q")) {
+                double x1, y1, x, y;
+                if (!parser.get_double (out x1)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out y1)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out x)) {
+                    loaded_successfully = false;
+                    break;
+                } else if (!parser.get_double (out y)) {
+                    loaded_successfully = false;
+                    break;
+                }
+
+                segments += new PathSegment.quadratic (x1, y1, x, y);
+                current_x = x;
+                current_y = y;
+                parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
             } else if (parser.match ("A")) {
                 double rx, ry, angle;
                 int large_arc, sweep;

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -77,6 +77,26 @@ public class Path : Element {
                 current_x = x;
                 current_y = y;
                 parsed.append_printf ("L %f, %f ", x, y);
+            } else if (parser.match ("H")) {
+                double x;
+                if (!parser.get_double (out x)) {
+                    loaded_successfully = false;
+                    break;
+                }
+
+                segments += new PathSegment.line (x, current_y);
+                current_x = x;
+                parsed.append_printf ("H %f ", x);
+            } else if (parser.match ("V")) {
+                double y;
+                if (!parser.get_double (out y)) {
+                    loaded_successfully = false;
+                    break;
+                }
+
+                segments += new PathSegment.line (current_x, y);
+                current_y = y;
+                parsed.append_printf ("V %f ", y);
             } else if (parser.match ("C")) {
                 double x1, x2, y1, y2, x, y;
                 if (!parser.get_double (out x1)) {

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -45,6 +45,7 @@ public class Path : Element {
         var segments = new PathSegment[] {};
         var parser = new Parser (description);
         var parsed = new StringBuilder ();
+        var loaded_first = false;
         double start_x = 0;
         double start_y = 0;
         double current_x = 0;
@@ -52,6 +53,14 @@ public class Path : Element {
         bool loaded_successfully = true;
         while (!parser.empty ()) {
             if (parser.match("M")) {
+                if (loaded_first) {
+                    // Paths with disconnected segments aren't supported yet.
+                    loaded_successfully = false;
+                    break;
+                }
+
+                loaded_first = true;
+
                 if (!parser.get_double (out start_x)) {
                     loaded_successfully = false;
                     break;

--- a/src/data/Path.vala
+++ b/src/data/Path.vala
@@ -61,36 +61,73 @@ public class Path : Element {
                 }
 
                 loaded_first = true;
-                loaded_successfully = PathSegment.load_moves (parser, parsed, segments, out start_x, out start_y, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_moves (parser, parsed, segments, out start_x, out start_y, ref current_x, ref current_y, false);
                 break;
             case "L":
-                loaded_successfully = PathSegment.load_lines (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_lines (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "H":
-                loaded_successfully = PathSegment.load_horizontal_lines (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_horizontal_lines (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "V":
-                loaded_successfully = PathSegment.load_vertical_lines (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_vertical_lines (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "C":
-                loaded_successfully = PathSegment.load_curves (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_curves (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "S":
-                loaded_successfully = PathSegment.load_smooth_curves (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_smooth_curves (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "Q":
-                loaded_successfully = PathSegment.load_quadratics (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_quadratics (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "T":
-                loaded_successfully = PathSegment.load_smooth_quadratics (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_smooth_quadratics (parser, parsed, segments, ref current_x, ref current_y, false);
                 break;
             case "A":
-                loaded_successfully = PathSegment.load_arcs (parser, parsed, segments, ref current_x, ref current_y);
+                loaded_successfully = PathSegment.load_arcs (parser, parsed, segments, ref current_x, ref current_y, false);
+                break;
+            case "m":
+                if (loaded_first) {
+                    // Paths with disconnected segments aren't supported yet.
+                    loaded_successfully = false;
+                    break;
+                }
+
+                loaded_first = true;
+                loaded_successfully = PathSegment.load_moves (parser, parsed, segments, out start_x, out start_y, ref current_x, ref current_y, true);
+                break;
+            case "l":
+                loaded_successfully = PathSegment.load_lines (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "h":
+                loaded_successfully = PathSegment.load_horizontal_lines (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "v":
+                loaded_successfully = PathSegment.load_vertical_lines (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "c":
+                loaded_successfully = PathSegment.load_curves (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "s":
+                loaded_successfully = PathSegment.load_smooth_curves (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "q":
+                loaded_successfully = PathSegment.load_quadratics (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "t":
+                loaded_successfully = PathSegment.load_smooth_quadratics (parser, parsed, segments, ref current_x, ref current_y, true);
+                break;
+            case "a":
+                loaded_successfully = PathSegment.load_arcs (parser, parsed, segments, ref current_x, ref current_y, true);
                 break;
             case "Z":
+            case "z":
                 // Ends the path, back to the beginning.
                 if (start_x != current_x || start_y != current_y) {
                     segments.add (new PathSegment.line (start_x, start_y));
+                    current_x = start_x;
+                    current_y = start_y;
                 }
 
                 parsed.append_printf ("Z ");

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -13,20 +13,28 @@ public class PathSegment : Segment {
         }
         set {
             if (_segment_type == value) {
-                _segment_type = value;
                 return;
             }
-            _segment_type = value;
-            if (_segment_type == CURVE) {
-                var dx = end.x - start.x;
-                var dy = end.y - start.y;
-                p1 = {start.x + dx / 4, start.y + dy / 4};
-                p2 = {end.x - dx / 4, end.y - dy / 4};
-            } else if (_segment_type == QUADRATIC) {
-                var dx = end.x - start.x;
-                var dy = end.y - start.y;
-                p1 = {start.x + dx / 2, start.y + dy / 2};
-            } else if (_segment_type == ARC) {
+            if (value == CURVE) {
+                if (_segment_type == QUADRATIC) {
+                    p2 = {(2*p1.x + end.x) / 3, (2*p1.y + end.y) / 3};
+                    p1 = {(2*p1.x + start.x) / 3, (2*p1.y + start.y) / 3};
+                } else {
+                    var dx = end.x - start.x;
+                    var dy = end.y - start.y;
+                    p1 = {start.x + dx / 4, start.y + dy / 4};
+                    p2 = {end.x - dx / 4, end.y - dy / 4};
+                }
+            } else if (value == QUADRATIC) {
+                if (_segment_type == CURVE) {
+                    // Approximate the same curve
+                    p1 = {(3*p1.x + 3*p2.x - start.x - end.x) / 4, (3*p1.y + 3*p2.y - start.y - end.y) / 4};
+                } else {
+                    var dx = end.x - start.x;
+                    var dy = end.y - start.y;
+                    p1 = {start.x + dx / 2, start.y + dy / 2};
+                }
+            } else if (value == ARC) {
                 var dx = end.x - start.x;
                 var dy = end.y - start.y;
                 angle = Math.PI + Math.atan2 (dy, dx);
@@ -37,6 +45,7 @@ public class PathSegment : Segment {
                 // Center has triggers to update start and end, so it goes last
                 center = {start.x + dx / 2, start.y + dy / 2};
             }
+            _segment_type = value;
         }
     }
 

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -289,12 +289,17 @@ public class PathSegment : Segment {
         this.end = {x, y};
     }
 
-    public static bool load_moves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, out double start_x, out double start_y, ref double current_x, ref double current_y) {
+    public static bool load_moves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, out double start_x, out double start_y, ref double current_x, ref double current_y, bool relative) {
         if (!parser.get_double (out start_x)) {
             start_y = 0;
             return false;
         } else if (!parser.get_double (out start_y)) {
             return false;
+        }
+
+        if (relative) {
+            start_x += current_x;
+            start_y += current_y;
         }
 
         current_x = start_x;
@@ -308,6 +313,11 @@ public class PathSegment : Segment {
                 return false;
             }
 
+            if (relative) {
+                x += current_x;
+                y += current_y;
+            }
+
             segments.add (new PathSegment.line (x, y));
             current_x = x;
             current_y = y;
@@ -317,12 +327,17 @@ public class PathSegment : Segment {
         return true;
     }
 
-    public static bool load_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x, y;
         bool loaded_once = false;
         while (parser.get_double (out x)) {
             if (!parser.get_double (out y)) {
                 return false;
+            }
+
+            if (relative) {
+                x += current_x;
+                y += current_y;
             }
 
             segments.add (new PathSegment.line (x, y));
@@ -335,10 +350,14 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_horizontal_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_horizontal_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x;
         bool loaded_once = false;
         while (parser.get_double (out x)) {
+            if (relative) {
+                x += current_x;
+            }
+
             segments.add (new PathSegment.line (x, current_y));
             current_x = x;
             parsed.append_printf ("H %f ", x);
@@ -348,10 +367,14 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_vertical_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_vertical_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double y;
         bool loaded_once = false;
         while (parser.get_double (out y)) {
+            if (relative) {
+                y += current_y;
+            }
+
             segments.add (new PathSegment.line (current_x, y));
             current_y = y;
             parsed.append_printf ("V %f ", y);
@@ -361,7 +384,7 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x1, x2, y1, y2, x, y;
         bool loaded_once = false;
         while (parser.get_double (out x1)) {
@@ -377,6 +400,15 @@ public class PathSegment : Segment {
                 return false;
             }
 
+            if (relative) {
+                x1 += current_x;
+                y1 += current_y;
+                x2 += current_x;
+                y2 += current_y;
+                x += current_x;
+                y += current_y;
+            }
+
             segments.add (new PathSegment.curve (x1, y1, x2, y2, x, y));
             current_x = x;
             current_y = y;
@@ -387,7 +419,7 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_smooth_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_smooth_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x1, y1, x2, y2, x, y;
         bool loaded_once = false;
         while (parser.get_double (out x2)) {
@@ -397,6 +429,13 @@ public class PathSegment : Segment {
                 return false;
             } else if (!parser.get_double (out y)) {
                 return false;
+            }
+
+            if (relative) {
+                x2 += current_x;
+                y2 += current_y;
+                x += current_x;
+                y += current_y;
             }
 
             x1 = current_x;
@@ -417,7 +456,7 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x1, y1, x, y;
         bool loaded_once = false;
         while (parser.get_double (out x1)) {
@@ -427,6 +466,13 @@ public class PathSegment : Segment {
                 return false;
             } else if (!parser.get_double (out y)) {
                 return false;
+            }
+
+            if (relative) {
+                x1 += current_x;
+                y1 += current_y;
+                x += current_x;
+                y += current_y;
             }
 
             segments.add (new PathSegment.quadratic (x1, y1, x, y));
@@ -439,12 +485,17 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_smooth_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_smooth_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double x1, y1, x, y;
         bool loaded_once = false;
         while (parser.get_double (out x)) {
             if (!parser.get_double (out y)) {
                 return false;
+            }
+
+            if (relative) {
+                x += current_x;
+                y += current_y;
             }
 
             x1 = current_x;
@@ -465,7 +516,7 @@ public class PathSegment : Segment {
         return loaded_once;
     }
 
-    public static bool load_arcs (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+    public static bool load_arcs (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y, bool relative) {
         double rx, ry, angle;
         int large_arc, sweep;
         double x, y;
@@ -483,6 +534,11 @@ public class PathSegment : Segment {
                 return false;
             } else if (!parser.get_double (out y)) {
                 return false;
+            }
+
+            if (relative) {
+                x += current_x;
+                y += current_y;
             }
 
             angle = angle * Math.PI / 180;

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -2,6 +2,7 @@ public enum SegmentType {
     NONE,
     LINE,
     CURVE,
+    QUADRATIC,
     ARC
 }
 
@@ -21,6 +22,8 @@ public class PathSegment : Segment {
             if (_segment_type == CURVE) {
                 command.add_value (this, "p1", p1, p1);
                 command.add_value (this, "p2", p2, p2);
+            } else if (_segment_type == QUADRATIC) {
+                command.add_value (this, "p1", p1, p1);
             } else if (_segment_type == ARC) {
                 command.add_value (this, "center", center, center);
                 command.add_value (this, "angle", angle, angle);
@@ -37,6 +40,11 @@ public class PathSegment : Segment {
                 p2 = {end.x - dx / 4, end.y - dy / 4};
                 command.add_value (this, "p1", p1, p1);
                 command.add_value (this, "p2", p2, p2);
+            } else if (_segment_type == QUADRATIC) {
+                var dx = end.x - start.x;
+                var dy = end.y - start.y;
+                p1 = {start.x + dx / 2, start.y + dy / 2};
+                command.add_value (this, "p1", p1, p1);
             } else if (_segment_type == ARC) {
                 var dx = end.x - start.x;
                 var dy = end.y - start.y;
@@ -140,7 +148,7 @@ public class PathSegment : Segment {
         }
     }
 
-    // Control points, used for CURVE segments
+    // Control points, used for CURVE and QUADRATIC segments
     public Point p1 { get; set; }
     public Point p2 { get; set; }
 
@@ -280,6 +288,12 @@ public class PathSegment : Segment {
         this.p2 = {x2, y2};
     }
 
+    public PathSegment.quadratic (double x1, double y1, double x, double y) {
+        segment_type = QUADRATIC;
+        this.end = {x, y};
+        this.p1 = {x1, y1};
+    }
+
     public PathSegment.arc (double x, double y, double xc, double yc, double rx, double ry, double angle, bool reverse) {
         segment_type = ARC;
         this.center = {xc, yc};
@@ -411,6 +425,8 @@ public class PathSegment : Segment {
                 return "L %f %f".printf (end.x, end.y);
             case CURVE:
                 return "C %f %f %f %f %f %f".printf (p1.x, p1.y, p2.x, p2.y, end.x, end.y);
+            case QUADRATIC:
+                return "Q %f %f %f %f".printf (p1.x, p1.y, end.x, end.y);
             case ARC:
                 var start = start_angle;
                 var end = end_angle;
@@ -441,6 +457,8 @@ public class PathSegment : Segment {
                 return new PathSegment.line (end.x, end.y);
             case CURVE:
                 return new PathSegment.curve (p1.x, p1.y, p2.x, p2.y, end.x, end.y);
+            case QUADRATIC:
+                return new PathSegment.quadratic (p1.x, p1.y, end.x, end.y);
             case ARC:
                 return new PathSegment.arc (end.x, end.y, center.x, center.y, rx, ry, angle, reverse);
             default:
@@ -466,6 +484,13 @@ public class PathSegment : Segment {
                 Point s = {(r1.x + r2.x) / 2, (r1.y + r2.y) / 2};
                 first = new PathSegment.curve (q1.x, q1.y, r1.x, r1.y, s.x, s.y);
                 last = new PathSegment.curve (r2.x, r2.y, q3.x, q3.y, end.x, end.y);
+                break;
+            case QUADRATIC:
+                Point r1 = {(start.x + p1.x) / 2, (start.y + p1.y) / 2};
+                Point r2 = {(p1.x + end.x) / 2, (p1.y + end.y) / 2};
+                Point s = {(r1.x + r2.x) / 2, (r1.y + r2.y) / 2};
+                first = new PathSegment.quadratic (r1.x, r1.y, s.x, s.y);
+                last = new PathSegment.quadratic (r2.x, r2.y, end.x, end.y);
                 break;
             case ARC:
                 // ARC segments don't work very well together.
@@ -496,6 +521,9 @@ public class PathSegment : Segment {
                 break;
             case CURVE:
                 cr.curve_to (p1.x, p1.y, p2.x, p2.y, end.x, end.y);
+                break;
+            case QUADRATIC:
+                cr.curve_to ((start.x + 2*p1.x)/3, (start.y + 2*p1.y)/3, (2*p1.x + end.x) / 3, (2*p1.y + end.y) / 3, end.x, end.y);
                 break;
             case ARC:
                 cr.save ();
@@ -595,6 +623,15 @@ public class PathSegment : Segment {
                 cr.arc (p2.x, p2.y, 6 / zoom, 0, Math.PI * 2);
                 cr.new_sub_path ();
                 break;
+            case SegmentType.QUADRATIC:
+                cr.move_to (start.x, start.y);
+                cr.line_to (p1.x, p1.y);
+                cr.line_to (end.x, end.y);
+                cr.set_source_rgba (0, 0.5, 1, 0.8);
+                cr.stroke ();
+                cr.arc (p1.x, p1.y, 6 / zoom, 0, Math.PI * 2);
+                cr.new_sub_path ();
+                break;
             case SegmentType.ARC:
                 cr.move_to (topleft.x, topleft.y);
                 cr.line_to (topright.x, topright.y);
@@ -651,6 +688,13 @@ public class PathSegment : Segment {
                     return true;
                 }
                 break;
+            case QUADRATIC:
+                if ((x - p1.x).abs () <= tolerance &&
+                    (y - p1.y).abs () <= tolerance) {
+                    handle = new BaseHandle(this, "p1", new Gee.ArrayList<ContextOption> ());
+                    return true;
+                }
+                break;
             case ARC:
                 if ((x - controller.x).abs () <= tolerance &&
                     (y - controller.y).abs () <= tolerance) {
@@ -704,6 +748,7 @@ public class PathSegment : Segment {
         var segment_type_options = new Gee.HashMap<string, int> ();
         segment_type_options.set (_("Line"), SegmentType.LINE);
         segment_type_options.set (_("Curve"), SegmentType.CURVE);
+        segment_type_options.set (_("Quadratic Curve"), SegmentType.QUADRATIC);
         segment_type_options.set (_("Arc"), SegmentType.ARC);
         options.add (new ContextOption.options (_("Change segment to:"), this, "segment_type", segment_type_options));
         return options;

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -1,5 +1,4 @@
 public enum SegmentType {
-    NONE,
     LINE,
     CURVE,
     QUADRATIC,
@@ -7,13 +6,13 @@ public enum SegmentType {
 }
 
 public class PathSegment : Segment {
-    private SegmentType _segment_type = NONE;
+    private SegmentType _segment_type;
     public SegmentType segment_type {
         get {
             return _segment_type;
         }
         set {
-            if (_segment_type == NONE || _segment_type == value) {
+            if (_segment_type == value) {
                 _segment_type = value;
                 return;
             }
@@ -303,8 +302,6 @@ public class PathSegment : Segment {
         this.reverse = reverse;
         this.end = {x, y};
     }
-
-    private PathSegment.none () {}
     
     public override void begin (string property) {
         switch (property) {

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -60,7 +60,7 @@ public class PathSegment : Segment {
             if (next_binding != null) {
                 next_binding.unbind ();
             }
-            
+
             _next = value;
             _next.prev = this;
             next_binding = bind_property ("end", _next, "start", BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
@@ -151,7 +151,7 @@ public class PathSegment : Segment {
     public double rx { get; set; default = 16; }
     public double ry { get; set; default = 16; }
     public double angle { get; set; }
-    
+
     private bool _reverse;
     public bool reverse {
         get {
@@ -218,7 +218,7 @@ public class PathSegment : Segment {
             end = point_from_angle(end_angle);
         }
     }
-    
+
     public Point bottomright {
         get {
             return {center.x + Math.cos (angle) * rx - Math.sin (angle) * ry,
@@ -246,7 +246,7 @@ public class PathSegment : Segment {
             end = point_from_angle(end_angle);
         }
     }
-    
+
     // Backups for undo history
     private SegmentType previous_segment_type;
     private Point previous_start;
@@ -259,7 +259,7 @@ public class PathSegment : Segment {
     private double previous_angle;
 
     public signal void request_split (PathSegment s);
-            
+
     // Constructors
     public PathSegment.line (double x, double y) {
         segment_type = LINE;
@@ -280,15 +280,243 @@ public class PathSegment : Segment {
     }
 
     public PathSegment.arc (double x, double y, double xc, double yc, double rx, double ry, double angle, bool reverse) {
-        segment_type = ARC;
-        this.center = {xc, yc};
+        _segment_type = ARC;
+        this._center = {xc, yc};
         this.rx = rx;
         this.ry = ry;
         this.angle = angle;
         this.reverse = reverse;
         this.end = {x, y};
     }
-    
+
+    public static bool load_moves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, out double start_x, out double start_y, ref double current_x, ref double current_y) {
+        if (!parser.get_double (out start_x)) {
+            start_y = 0;
+            return false;
+        } else if (!parser.get_double (out start_y)) {
+            return false;
+        }
+
+        current_x = start_x;
+        current_y = start_y;
+        parsed.append_printf ("M %f, %f ", start_x, start_y);
+
+        // Additional coordinates after an 'M' command are lines.
+        double x, y;
+        while (parser.get_double (out x)) {
+            if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            segments.add (new PathSegment.line (x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("L %f, %f ", x, y);
+        }
+
+        return true;
+    }
+
+    public static bool load_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out x)) {
+            if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            segments.add (new PathSegment.line (x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("L %f, %f ", x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_horizontal_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x;
+        bool loaded_once = false;
+        while (parser.get_double (out x)) {
+            segments.add (new PathSegment.line (x, current_y));
+            current_x = x;
+            parsed.append_printf ("H %f ", x);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_vertical_lines (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double y;
+        bool loaded_once = false;
+        while (parser.get_double (out y)) {
+            segments.add (new PathSegment.line (current_x, y));
+            current_y = y;
+            parsed.append_printf ("V %f ", y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x1, x2, y1, y2, x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out x1)) {
+            if (!parser.get_double (out y1)) {
+                return false;
+            } else if (!parser.get_double (out x2)) {
+                return false;
+            } else if (!parser.get_double (out y2)) {
+                return false;
+            } else if (!parser.get_double (out x)) {
+                return false;
+            } else if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            segments.add (new PathSegment.curve (x1, y1, x2, y2, x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("C %f, %f, %f, %f, %f, %f ", x1, y1, x2, y2, x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_smooth_curves (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x1, y1, x2, y2, x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out x2)) {
+            if (!parser.get_double (out y2)) {
+                return false;
+            } else if (!parser.get_double (out x)) {
+                return false;
+            } else if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            x1 = current_x;
+            y1 = current_y;
+
+            if (!segments.is_empty && segments.last ().segment_type == CURVE) {
+                x1 = 2 * current_x - segments.last ().p2.x;
+                y1 = 2 * current_y - segments.last ().p2.y;
+            }
+
+            segments.add (new PathSegment.curve (x1, y1, x2, y2, x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("S %f %f %f %f ", x2, y2, x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x1, y1, x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out x1)) {
+            if (!parser.get_double (out y1)) {
+                return false;
+            } else if (!parser.get_double (out x)) {
+                return false;
+            } else if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            segments.add (new PathSegment.quadratic (x1, y1, x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("Q %f, %f, %f, %f ", x1, y1, x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_smooth_quadratics (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double x1, y1, x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out x)) {
+            if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            x1 = current_x;
+            y1 = current_y;
+
+            if (!segments.is_empty && segments.last().segment_type == QUADRATIC) {
+                x1 = 2 * current_x - segments.last().p1.x;
+                y1 = 2 * current_y - segments.last().p1.y;
+            }
+
+            segments.add (new PathSegment.quadratic (x1, y1, x, y));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("T %f, %f ", x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
+    public static bool load_arcs (Parser parser, StringBuilder parsed, Gee.List<PathSegment> segments, ref double current_x, ref double current_y) {
+        double rx, ry, angle;
+        int large_arc, sweep;
+        double x, y;
+        bool loaded_once = false;
+        while (parser.get_double (out rx)) {
+            if (!parser.get_double (out ry)) {
+                return false;
+            } else if (!parser.get_double (out angle)) {
+                return false;
+            } else if (!parser.get_int (out large_arc)) {
+                return false;
+            } else if (!parser.get_int (out sweep)) {
+                return false;
+            } else if (!parser.get_double (out x)) {
+                return false;
+            } else if (!parser.get_double (out y)) {
+                return false;
+            }
+
+            angle = angle * Math.PI / 180;
+
+            var x1 = (current_x - x) / 2 * Math.cos (angle) + Math.sin (angle) * (current_y - y) / 2;
+            var y1 = -Math.sin (angle) * (current_x - x) / 2 + Math.cos (angle) * (current_y - y) / 2;
+            var dt = (x1 * x1) / (rx * rx) + (y1 * y1) / (ry * ry);
+
+            if (dt > 1) {
+                rx = rx * Math.sqrt (dt);
+                ry = ry * Math.sqrt (dt);
+            }
+
+            var coefficient = Math.sqrt ((rx * rx * ry * ry - rx * rx * y1 * y1 - ry * ry * x1 * x1) / (rx * rx * y1 * y1 + ry * ry * x1 * x1));
+
+            if (large_arc == sweep) {
+                coefficient = -coefficient;
+            }
+
+            var cx1 = coefficient * rx * y1 / ry;
+            var cy1 = -coefficient * ry * x1 / rx;
+            var cx = cx1 * Math.cos (angle) - cy1 * Math.sin (angle) + (current_x + x) / 2;
+            var cy = cx1 * Math.sin (angle) + cy1 * Math.cos (angle) + (current_y + y) / 2;
+
+            segments.add (new PathSegment.arc (x, y, cx, cy, rx, ry, angle, (sweep == 0)));
+            current_x = x;
+            current_y = y;
+            parsed.append_printf ("A %f, %f, %f, %d, %d, %f, %f ", rx, ry, angle, large_arc, sweep, x, y);
+            loaded_once = true;
+        }
+
+        return loaded_once;
+    }
+
     public override void begin (string property) {
         switch (property) {
             case "start":
@@ -330,7 +558,7 @@ public class PathSegment : Segment {
                 break;
         }
     }
-    
+
     public override void finish (string property) {
         var command = new Command ();
         switch (property) {
@@ -499,6 +727,7 @@ public class PathSegment : Segment {
                 last = null;
                 return;
         }
+
         prev.next = first;
         last.prev = first;
         last.next = next;
@@ -564,7 +793,7 @@ public class PathSegment : Segment {
 
             var qx = px - ex;
             var qy = py - ey;
-            
+
             if (qx.is_nan ()) {
                 error ("Didn't find closest point.");
             }
@@ -678,7 +907,7 @@ public class PathSegment : Segment {
                     handle = new BaseHandle(this, "p1", new Gee.ArrayList<ContextOption> ());
                     return true;
                 }
-                if ((x - p2.x).abs () <= tolerance && 
+                if ((x - p2.x).abs () <= tolerance &&
                     (y - p2.y).abs () <= tolerance) {
                     handle = new BaseHandle(this, "p2", new Gee.ArrayList<ContextOption> ());
                     return true;

--- a/src/data/PathSegment.vala
+++ b/src/data/PathSegment.vala
@@ -16,51 +16,27 @@ public class PathSegment : Segment {
                 _segment_type = value;
                 return;
             }
-            var command = new Command ();
-            command.add_value (this, "segment_type", _segment_type, value);
-            if (_segment_type == CURVE) {
-                command.add_value (this, "p1", p1, p1);
-                command.add_value (this, "p2", p2, p2);
-            } else if (_segment_type == QUADRATIC) {
-                command.add_value (this, "p1", p1, p1);
-            } else if (_segment_type == ARC) {
-                command.add_value (this, "center", center, center);
-                command.add_value (this, "angle", angle, angle);
-                command.add_value (this, "rx", rx, rx);
-                command.add_value (this, "ry", ry, ry);
-                command.add_value (this, "start", start, end);
-                command.add_value (this, "end", end, end);
-            }
             _segment_type = value;
             if (_segment_type == CURVE) {
                 var dx = end.x - start.x;
                 var dy = end.y - start.y;
                 p1 = {start.x + dx / 4, start.y + dy / 4};
                 p2 = {end.x - dx / 4, end.y - dy / 4};
-                command.add_value (this, "p1", p1, p1);
-                command.add_value (this, "p2", p2, p2);
             } else if (_segment_type == QUADRATIC) {
                 var dx = end.x - start.x;
                 var dy = end.y - start.y;
                 p1 = {start.x + dx / 2, start.y + dy / 2};
-                command.add_value (this, "p1", p1, p1);
             } else if (_segment_type == ARC) {
                 var dx = end.x - start.x;
                 var dy = end.y - start.y;
-                center = {start.x + dx / 2, start.y + dy / 2};
                 angle = Math.PI + Math.atan2 (dy, dx);
                 start_angle = 0;
                 end_angle = Math.PI;
                 rx = Math.hypot (dy, dx) / 2;
                 ry = rx / 2;
-                command.add_value (this, "center", center, center);
-                command.add_value (this, "angle", angle, angle);
-                command.add_value (this, "rx", rx, rx);
-                command.add_value (this, "ry", ry, ry);
-                command.add_value (this, "start", start, end);
-                command.add_value (this, "end", end, end);
+                // Center has triggers to update start and end, so it goes last
+                center = {start.x + dx / 2, start.y + dy / 2};
             }
-            add_command (command);
         }
     }
 
@@ -263,6 +239,7 @@ public class PathSegment : Segment {
     }
     
     // Backups for undo history
+    private SegmentType previous_segment_type;
     private Point previous_start;
     private Point previous_end;
     private Point previous_p1;
@@ -337,6 +314,11 @@ public class PathSegment : Segment {
                 previous_end = end;
                 previous_angle = angle;
                 break;
+            case "segment_type":
+                previous_segment_type = segment_type;
+                previous_p1 = p1;
+                previous_p2 = p2;
+                break;
         }
     }
     
@@ -374,6 +356,14 @@ public class PathSegment : Segment {
                 command.add_value (this, "angle", angle, previous_angle);
                 command.add_value (this, "start", start, previous_start);
                 command.add_value (this, "end", end, previous_end);
+                break;
+            case "segment_type":
+                command.add_value (this, "segment_type", segment_type, previous_segment_type);
+                command.add_value (this, "p1", p1, previous_p1);
+                command.add_value (this, "p2", p2, previous_p2);
+                break;
+            default:
+                warning ("Unimplemented command property '%s'", property);
                 break;
         }
         add_command (command);


### PR DESCRIPTION
This adds support for loading all remaining segment types:
* quadratic curves
* horizontal lines
* vertical lines
* smooth quadratic curves
* smooth cubic curves.

These are converted to standard lines and curves (and the new quadratic curve). Adding editor support for smooth curves, horizontal lines, and vertical lines will come in a later update.